### PR TITLE
Feat: 기존 창과 팝업창 간에 데이터 공유하기 구현

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -48,12 +48,12 @@ export default function Login({ modal }: Props) {
   }
 
   function onClickLogin(provider: Provider) {
-    const left = window.screen.width / 2 - 300;
-    const top = window.screen.height / 2 - 300;
+    const left = document.body.offsetWidth / 2 - 250;
+    const top = document.body.offsetHeight / 2 - 250;
 
     const url = `${baseURL}/auth/${provider}`;
     const target = `${provider}Login`;
-    const features = `left=${left},top=${top},width=600,height=600`;
+    const features = `left=${left},top=${top},width=500,height=500`;
 
     if (!newWindowRef.current || newWindowRef.current.closed) {
       newWindowRef.current = window.open(url, target, features);

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -27,6 +27,7 @@ type Provider = 'google' | 'kakao' | 'naver';
 export default function Login({ modal }: Props) {
   const modalDispatch = useModalDispatch();
   const newWindowRef = useRef<Window | null>();
+  const prevWindowTargetRef = useRef<string>();
 
   function closeModal() {
     modalDispatch({ type: 'CLOSE_MODAL' });
@@ -54,7 +55,17 @@ export default function Login({ modal }: Props) {
     const target = `${provider}Login`;
     const features = `left=${left},top=${top},width=600,height=600`;
 
-    newWindowRef.current = window.open(url, target, features);
+    if (!newWindowRef.current || newWindowRef.current.closed) {
+      newWindowRef.current = window.open(url, target, features);
+    } else if (prevWindowTargetRef.current == target) {
+      newWindowRef.current.focus();
+    } else {
+      newWindowRef.current.close();
+      newWindowRef.current = window.open(url, target, features);
+      newWindowRef.current?.focus();
+    }
+
+    prevWindowTargetRef.current = target;
 
     window.removeEventListener('message', receiveMessage);
     window.addEventListener('message', receiveMessage);

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import GoogleLoginIcon from '@assets/google-login.svg';
 import KakaoLoginIcon from '@assets/kakao-login.svg';
 import NaverLoginIcon from '@assets/naver-login.svg';
@@ -5,6 +6,7 @@ import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
 import { useModalDispatch } from '@context/ModalContext';
 import { baseURL } from '@services/index';
+import { User } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
@@ -15,25 +17,54 @@ interface LoginProps {
   onClickLogin: React.MouseEventHandler<HTMLButtonElement>;
 }
 
+interface MessageData {
+  authenticated: boolean;
+  user: User | null;
+}
+
 type Provider = 'google' | 'kakao' | 'naver';
 
 export default function Login({ modal }: Props) {
   const modalDispatch = useModalDispatch();
+  const newWindowRef = useRef<Window | null>();
 
   function closeModal() {
     modalDispatch({ type: 'CLOSE_MODAL' });
+  }
+
+  function receiveMessage(e: MessageEvent<MessageData>) {
+    // 팝업창으로부터 메세지를 수신받아 로그인 처리
+    if (e.origin != window.location.origin) return;
+    if (newWindowRef.current) {
+      if (e.data.authenticated && e.data.user) {
+        console.log('user', e.data.user);
+      } else {
+        window.alert('로그인에 실패했습니다.');
+      }
+      newWindowRef.current.close();
+      newWindowRef.current = null; // 로그인 성공 후에도, 실패 메세지 코드 블록이 실행되는 버그가 발생하여 이를 방지하기 위한 코드
+    }
   }
 
   function onClickLogin(provider: Provider) {
     const left = window.screen.width / 2 - 300;
     const top = window.screen.height / 2 - 300;
 
-    window.open(
-      `${baseURL}/auth/${provider}`,
-      `${provider}Login`,
-      `left=${left},top=${top},width=600,height=600`
-    );
+    const url = `${baseURL}/auth/${provider}`;
+    const target = `${provider}Login`;
+    const features = `left=${left},top=${top},width=600,height=600`;
+
+    newWindowRef.current = window.open(url, target, features);
+
+    window.removeEventListener('message', receiveMessage);
+    window.addEventListener('message', receiveMessage);
   }
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('message', receiveMessage);
+    };
+  }, []);
 
   return (
     <Modal modal={modal}>

--- a/src/pages/Authenticated/index.tsx
+++ b/src/pages/Authenticated/index.tsx
@@ -1,17 +1,34 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { login } from '@services/auth';
 
 export default function Authenticated() {
+  const windowOpenerRef = useRef<Window | null>(window.opener);
+
   useEffect(() => {
     login()
       .then(res => {
-        console.log(res.data);
-        window.close();
+        if (res.data.success && windowOpenerRef.current) {
+          windowOpenerRef.current.postMessage(
+            { authenticated: true, user: res.data.user },
+            {
+              targetOrigin: window.location.origin,
+            }
+          );
+        }
       })
       .catch(error => {
+        if (windowOpenerRef.current) {
+          windowOpenerRef.current.postMessage(
+            {
+              authenticated: false,
+              user: null,
+            },
+            { targetOrigin: window.location.origin }
+          );
+        }
         console.error(error);
       });
   }, []);
 
-  return <div>인증 성공</div>;
+  return <></>;
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,12 @@
+import { User } from '@typings/db';
 import { authAPI } from '.';
 
+interface AuthResponse {
+  success: boolean;
+  message: string;
+  user: User;
+}
+
 export function login() {
-  return authAPI.get('/login');
+  return authAPI.get<AuthResponse>('/login');
 }

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  provider: string | null;
+}


### PR DESCRIPTION
## What is this PR?

로그인 실행후 가져온 결과를 기존 페이지에 연결하기

## Changes

기존 페이지에서 오픈한 팝업창에서 로그인을 실행한 후, 그 결과를 기존 페이지로 갖고 올 수 없음.
팝업창에서 setState를 실행하더라도 각각 독립된 세션이기 때문에, 기존 페이지로 데이터를 전달할 수 없는 문제가 발생함.

window.postMessage 메서드를 사용하여 분리된 윈도우 간에 메세지를 주고 받는 형식으로 데이터를 주고 받도록 구현함
(로그인 완료 후, 팝업창에서 기존 창으로 데이터를 보내고, 데이터를 확인한 기존 창은 팝업창을 닫음)

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 로그인 성공 or 실패 결과 메세지를 기존 페이지로 갖고 오는 것 확인

**Bug:**
로그인 성공 후, 팝업창을 닫은 후에도 실패 메세지가 실행되는 버그 존재함.
팝업창에 대한 참조가 남아있어 발생하는 것으로 파악하여, window.close 메서드 실행 후 참조값 null로 변경함.

## Etc

아래 소스 코드 참고하여 작성함.
- [react-linkedin-login-oauth2](https://github.com/nvh95/react-linkedin-login-oauth2), [react-passport-login-oauth2](https://github.com/airmeet/react-passport-login-oauth2)
- [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#examples), [window.open](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#reuse_existing_windows_and_avoid_target_blank)