### PR TITLE
Feat: 로그인, 로그아웃 실행으로 변경된 사용자 정보 화면에 표시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.3.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "zustand": "^4.1.1"
       },
       "devDependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
@@ -37,7 +38,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "fork-ts-checker-webpack-plugin": "^7.2.13",
         "html-webpack-plugin": "^5.5.0",
-        "husky": "^8.0.1",
+        "husky": "^8.0.0",
         "prettier": "^2.7.1",
         "react-refresh": "^0.14.0",
         "ts-loader": "^9.3.1",
@@ -9153,6 +9154,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9803,6 +9812,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+      "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -16491,6 +16523,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16939,6 +16977,14 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
+      "integrity": "sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "zustand": "^4.1.1"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,11 +3,18 @@ import { Link } from 'react-router-dom';
 import Button from '@components/common/Button';
 import Login from '@components/Login';
 import { useModal, useModalDispatch } from '@context/ModalContext';
+import { logout } from '@services/auth';
+import { useUserStore } from '@store/.';
+import { User } from '@typings/db';
 import { styles } from './styles';
 
 export default function Header() {
   const modal = useModal();
   const modalDispatch = useModalDispatch();
+  const { user, setUser } = useUserStore(state => ({
+    user: state.user,
+    setUser: state.setUser,
+  }));
 
   function onClickLogin(e: React.MouseEvent) {
     if (e.target instanceof HTMLElement) {
@@ -17,16 +24,38 @@ export default function Header() {
     }
   }
 
+  function onClickLogout() {
+    logout()
+      .then(res => {
+        if (res.data.success) {
+          setUser(null);
+        }
+      })
+      .catch(error => {
+        window.alert('로그아웃 처리에 실패했습니다.');
+        console.error(error);
+      });
+  }
+
+  function successLogin(user: User) {
+    setUser(user);
+    modalDispatch({ type: 'CLOSE_MODAL' });
+  }
+
   return (
     <header>
       <div css={styles.headerInner}>
         <h1 css={styles.logo}>
           <Link to="/">MyTicket</Link>
         </h1>
-        <Button onClick={onClickLogin} data-modal="login">
-          로그인
-        </Button>
-        <Login modal={modal === 'login'} />
+        {user ? (
+          <Button onClick={onClickLogout}>로그아웃</Button>
+        ) : (
+          <Button onClick={onClickLogin} data-modal="login">
+            로그인
+          </Button>
+        )}
+        <Login modal={modal === 'login'} onSuccess={successLogin} />
       </div>
     </header>
   );

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -10,3 +10,7 @@ interface AuthResponse {
 export function login() {
   return authAPI.get<AuthResponse>('/login');
 }
+
+export function logout() {
+  return authAPI.post<Omit<AuthResponse, 'user'>>('/logout');
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,1 @@
+export * from './useUserStore';

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,12 @@
+import create from 'zustand';
+import { User } from '@typings/db';
+
+interface UserState {
+  user: User | null;
+  setUser: (user: User | null) => void;
+}
+
+export const useUserStore = create<UserState>(set => ({
+  user: null,
+  setUser: user => set(() => ({ user })),
+}));


### PR DESCRIPTION
## What is this PR?

close #10 

## Changes

- 팝업 창에서 기존 페이지로 메세지를 전달 받은 후, onSuccess 콜백 함수를 전달 받아 로그인 처리함.
경우에 따라 성공 후 실행해야 하는 로직이 달라질 수 있어 부모 컴포넌트에서 전달하는 콜백 형태로 작성함.

- user 상태를 zustand를 저장한 이유
기존에 리액트에서 제공하는 Context를 이용하여 user 정보를 저장할 수 있지만,
Context도 어느 정도의 패턴이 있어 일정 부분 작성해야 하는 코드가 있음.
zustand는 그보다 작성해야 하는 코드가 적고, Provider로 감싸주지 않아도 되어 선택함.

## Screenshot

|  기능  | 스크린샷 |
| :---------: | :------: |
| 로그인 | ![1_animation](https://user-images.githubusercontent.com/37580351/189481075-5c1c6474-5219-4820-98e4-fdf9f666d106.gif) |
| 로그아웃 | ![1_animation](https://user-images.githubusercontent.com/37580351/189481141-7e8b5e66-7c6e-4b87-accf-325c2dfb088c.gif) |


## Test Checklist

- [x] 로그인, 로그아웃 실행 완료 후 스토어에 저장된 사용자 정보 변경 확인 

## Etc

없음