### PR TITLE
Refactor: 모달 custom data 프로퍼티 삭제

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Button from '@components/common/Button';
 import Login from '@components/Login';
@@ -11,12 +10,8 @@ export default function Header() {
   const { modal, openModal, closeModal } = useModalStore();
   const { user, setUser } = useUserStore();
 
-  function onClickLogin(e: React.MouseEvent) {
-    if (e.target instanceof HTMLElement) {
-      if (e.target.dataset.modal) {
-        openModal(e.target.dataset.modal);
-      }
-    }
+  function onClickLogin() {
+    openModal('login');
   }
 
   function onClickLogout() {
@@ -46,9 +41,7 @@ export default function Header() {
         {user ? (
           <Button onClick={onClickLogout}>로그아웃</Button>
         ) : (
-          <Button onClick={onClickLogin} data-modal="login">
-            로그인
-          </Button>
+          <Button onClick={onClickLogin}>로그인</Button>
         )}
         <Login modal={modal === 'login'} onSuccess={successLogin} />
       </div>

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
 import { TeamList } from '@components/TeamList';
@@ -9,19 +8,13 @@ import { styles } from './styles';
 export default function TeamPicker() {
   const { modal, openModal, closeModal } = useModalStore();
 
-  function onClick(e: React.MouseEvent) {
-    if (e.target instanceof HTMLElement) {
-      if (e.target.dataset.modal === 'team-picker') {
-        openModal('team-picker');
-      }
-    }
+  function onClick() {
+    openModal('team-picker');
   }
 
   return (
     <section css={styles.inner}>
-      <Button onClick={onClick} data-modal="team-picker">
-        팀 선택하기
-      </Button>
+      <Button onClick={onClick}>팀 선택하기</Button>
       <Modal modal={modal === 'team-picker'}>
         <section css={styles.modalWrapper}>
           <div css={styles.modalHeader}>


### PR DESCRIPTION
## What is this PR?

close #19 

## Changes

- `data-modal` 사용 안하는 것으로 변경

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

클릭 요소에 data-modal 프로퍼티 값을 직접 전달하는 방식은 타입 체크가 이뤄지지 않아,
개발 중에 프로퍼티를 부여하는 것을 잊어버릴 확률이 높아 삭제함.

모달의 이름은 하드 코딩이 한번 필요하므로, 모달을 오픈하는 함수에서 직접 전달하도록 함.
