### PR TITLE
Refactor: setUser to loginUser, logoutUser

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,34 +1,24 @@
 import { Link } from 'react-router-dom';
 import Button from '@components/common/Button';
 import Login from '@components/Login';
-import { logout } from '@services/auth';
 import { useModalStore, useUserStore } from '@store/.';
 import { User } from '@typings/db';
 import { styles } from './styles';
 
 export default function Header() {
-  const { modal, openModal, closeModal } = useModalStore();
-  const { user, setUser } = useUserStore();
+  const modal = useModalStore(state => state.modal);
+  const openModal = useModalStore(state => state.openModal);
+  const closeModal = useModalStore(state => state.closeModal);
+  const user = useUserStore(state => state.user);
+  const loginUser = useUserStore(state => state.loginUser);
+  const logoutUser = useUserStore(state => state.logoutUser);
 
   function onClickLogin() {
     openModal('login');
   }
 
-  function onClickLogout() {
-    logout()
-      .then(res => {
-        if (res.data.success) {
-          setUser(null);
-        }
-      })
-      .catch(error => {
-        window.alert('로그아웃 처리에 실패했습니다.');
-        console.error(error);
-      });
-  }
-
   function successLogin(user: User) {
-    setUser(user);
+    loginUser(user);
     closeModal();
   }
 
@@ -39,7 +29,7 @@ export default function Header() {
           <Link to="/">MyTicket</Link>
         </h1>
         {user ? (
-          <Button onClick={onClickLogout}>로그아웃</Button>
+          <Button onClick={logoutUser}>로그아웃</Button>
         ) : (
           <Button onClick={onClickLogin}>로그인</Button>
         )}

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,17 +1,28 @@
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
+import { logout } from '@services/auth';
 import { User } from '@typings/db';
 
 interface UserState {
   user: User | null;
-  setUser: (user: User | null) => void;
+  loginUser(user: User): void;
+  logoutUser(): Promise<void>;
 }
 
 export const useUserStore = create<UserState>()(
   persist(
     set => ({
       user: null,
-      setUser: user => set({ user }),
+      loginUser: user => set({ user }),
+      logoutUser: async () => {
+        try {
+          await logout();
+          set({ user: null });
+        } catch (error) {
+          window.alert('로그아웃 처리에 실패했습니다.');
+          console.error(error);
+        }
+      },
     }),
     {
       name: 'user-storage',


### PR DESCRIPTION
## What is this PR?

close #24 

## Changes

- userStore 내부에 로그인, 로그아웃 시 사용자 변경 처리하도록 변경
(로그인의 경우는, Authenticated 컴포넌트에서 메세지를 받은 후 setState하기 때문에 비동기 처리하지 않음)

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 로그인, 로그아웃 정상 작동

## Etc

store 안에서 상태 뿐만 아니라 함수도 가져다 사용하여, setUser 보다는 좀 더 메서드를 특정하려고 함.
이렇게 하게 되면, api를 컴포넌트가 아닌 스토어에서 가져다 사용하게 됨.
이전보다 가져다 사용하는 메서드명이 구체적인 편이어서, 컴포넌트에서 코드가 쉽게 읽히는 장점이 있어 변경함.