### PR TITLE
Fix: 크롬 브라우저에서 나타는 메세지 수신 오류 수정

### DIFF
--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -24,7 +24,7 @@ interface ProviderProps {
 }
 
 interface MessageData {
-  authenticated: boolean;
+  from: string;
   user: User | null;
 }
 
@@ -61,16 +61,20 @@ export default function Login({ modal, onSuccess }: Props) {
 
   const receiveMessage = useCallback(
     (e: MessageEvent<MessageData>) => {
-      // 팝업창으로부터 메세지를 수신받아 로그인 처리
       if (e.origin != window.location.origin) return;
-      if (newWindowRef.current) {
-        if (e.data.authenticated && e.data.user) {
-          onSuccess(e.data.user);
-        } else {
-          window.alert('로그인에 실패했습니다.');
+
+      // Chrome browser에서만 발생하는 문제
+      // 계정 로그인 클릭 후, 같은 origin인 현재 window로부터 메세지가 한번 수신되는 문제가 발생함.
+      // 메세지를 보낸 window가 인증 팝업창이 아닌 경우에는 메세지를 수신받지 않도록 함.
+      if (e.source == newWindowRef.current) {
+        if (e.data.from == 'authentication') {
+          if (e.data.user) {
+            onSuccess(e.data.user);
+          } else {
+            window.alert('로그인에 실패했습니다.');
+          }
+          newWindowRef.current?.close();
         }
-        newWindowRef.current.close();
-        newWindowRef.current = null; // 로그인 성공 후에도, 실패 메세지 코드 블록이 실행되는 버그가 발생하여 이를 방지하기 위한 코드
       }
     },
     [onSuccess]
@@ -95,12 +99,10 @@ export default function Login({ modal, onSuccess }: Props) {
     }
 
     prevWindowTargetRef.current = target;
-
-    window.removeEventListener('message', receiveMessage);
-    window.addEventListener('message', receiveMessage);
   }
 
   useEffect(() => {
+    window.addEventListener('message', receiveMessage);
     return () => {
       window.removeEventListener('message', receiveMessage);
     };

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -57,7 +57,7 @@ const providers = [
 export default function Login({ modal, onSuccess }: Props) {
   const closeModal = useModalStore(state => state.closeModal);
   const newWindowRef = useRef<Window | null>();
-  const prevWindowTargetRef = useRef<string>();
+  const prevWindowUrlRef = useRef<string>();
 
   const receiveMessage = useCallback(
     (e: MessageEvent<MessageData>) => {
@@ -85,20 +85,19 @@ export default function Login({ modal, onSuccess }: Props) {
     const top = document.body.offsetHeight / 2 - 250;
 
     const url = `${baseURL}/auth/${provider}`;
-    const target = `${provider}Login`;
+    const target = 'authentication';
     const features = `left=${left},top=${top},width=500,height=500`;
 
     if (!newWindowRef.current || newWindowRef.current.closed) {
       newWindowRef.current = window.open(url, target, features);
-    } else if (prevWindowTargetRef.current == target) {
+    } else if (prevWindowUrlRef.current == url) {
       newWindowRef.current.focus();
     } else {
-      newWindowRef.current.close();
       newWindowRef.current = window.open(url, target, features);
       newWindowRef.current?.focus();
     }
 
-    prevWindowTargetRef.current = target;
+    prevWindowUrlRef.current = url;
   }
 
   useEffect(() => {

--- a/src/pages/Authenticated/index.tsx
+++ b/src/pages/Authenticated/index.tsx
@@ -7,23 +7,18 @@ export default function Authenticated() {
 
     login()
       .then(res => {
-        if (res.data.success && windowOpener) {
+        if (windowOpener) {
           windowOpener.postMessage(
-            { authenticated: true, user: res.data.user },
-            {
-              targetOrigin: window.location.origin,
-            }
+            { from: 'authentication', user: res.data.user },
+            window.location.origin
           );
         }
       })
       .catch(error => {
         if (windowOpener) {
           windowOpener.postMessage(
-            {
-              authenticated: false,
-              user: null,
-            },
-            { targetOrigin: window.location.origin }
+            { from: 'authentication', user: null },
+            window.location.origin
           );
         }
         console.error(error);


### PR DESCRIPTION
## What is this PR?

close #28 

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

- 브라우저 상관없이 오류가 나타나지 않도록
1. 메세지를 보낸 윈도우 객체가 팝업창인지 확인
2. 인증 페이지에서 보낸 메세지인지 구분할 수 있는 `from` 값 확인

- 로그인 컴포넌트의 생명주기에 맞춰, 메세지 수신 이벤트 추가 및 제거

- 팝업창 재사용 방식 변경
target 값을 동일하게 변경하여 어떤 소셜 계정 로그인이든 같은 팝업창을 재사용하여, 직접 팝업창을 닫는 코드를 삭제함.
다른 소셜 계정 로그인 클릭 구분을 위해 사용했던 target 값이 동일해졌으므로, `url` 로 대신함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 크롬 브라우저에서만 나타나는 오류인 것 확인. (사이트 쿠키, 기록 모두 삭제한 후 확인)

## Etc

메세지 수신 함수는 보안 상의 문제가 있기 때문에, 사용할 때 `origin`, `source` 프로퍼티를 사용하여 메세지를 보낸 윈도우를 확인하고, 받은 메세지 `data` 프로퍼티를 통해 한번 더 확인하는 것이 좋음. [참고](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns)