### PR TITLE
Fix: 팀 선택 모달창 wrapper overflowY: auto 적용

### DIFF
--- a/src/components/TeamPicker/styles.ts
+++ b/src/components/TeamPicker/styles.ts
@@ -19,6 +19,7 @@ export const styles = {
   modalWrapper: css({
     width: '100vw',
     height: '100vh',
+    overflowY: 'auto',
     [mq('sm')]: {
       width: 700,
       height: 'auto',


### PR DESCRIPTION
## What is this PR?

close #30 

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

- modal 영역을 감싸는 wrapper 요소의 width, height 값에 각각 100vw, 100vh 이 적용되어 있어 스크롤이 차단됨.
`overflowY: auto` 속성을 적용해 컨텐츠의 길이가 뷰포트 길이를 넘어가면 스크롤이 생성되도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| overflow: visible (기본값) | ![2_animation](https://user-images.githubusercontent.com/37580351/190920511-cf52b47b-b830-4eb9-a9cc-23bd6350fa03.gif) |
| overflowY: auto | ![1_animation](https://user-images.githubusercontent.com/37580351/190920508-5f47f792-5128-4e82-b2cb-e999da149a01.gif) |

## Test Checklist

- [x] 속성 적용에 따른 스크롤 움직임 확인 (스크린샷 참고)

## Etc

없음
