### PR TITLE
Refactor: 팀 선택 기능 비제어 컴포넌트로 관리

### DIFF
--- a/src/components/MyTeams/index.tsx
+++ b/src/components/MyTeams/index.tsx
@@ -1,0 +1,26 @@
+import Button from '@components/common/Button';
+import TeamPicker from '@components/TeamPicker';
+import { useModalStore, useUserStore } from '@store/.';
+import { colors } from '@styles/theme';
+import { styles } from './styles';
+
+export default function MyTeams() {
+  const user = useUserStore(state => state.user);
+  const openModal = useModalStore(state => state.openModal);
+
+  function addTeams() {
+    user ? openModal('team-picker') : openModal('login');
+  }
+
+  return (
+    <section css={styles.inner}>
+      <div css={styles.title}>
+        <h2>나의 팀</h2>
+        <Button onClick={addTeams} bgColor={colors.indigo[600]}>
+          팀 추가
+        </Button>
+        <TeamPicker />
+      </div>
+    </section>
+  );
+}

--- a/src/components/MyTeams/styles.ts
+++ b/src/components/MyTeams/styles.ts
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  inner: css({
+    padding: 20,
+    [mq('lg')]: {
+      width: 1200,
+      margin: '0 auto',
+    },
+  }),
+  title: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    h2: {
+      fontSize: '1.6rem',
+      fontWeight: 600,
+    },
+  }),
+};

--- a/src/components/TeamList/index.tsx
+++ b/src/components/TeamList/index.tsx
@@ -1,61 +1,28 @@
-import * as React from 'react';
-import HH from '@assets/team/HH.png';
-import HT from '@assets/team/HT.png';
-import KT from '@assets/team/KT.png';
-import LG from '@assets/team/LG.png';
-import LT from '@assets/team/LT.png';
-import NC from '@assets/team/NC.png';
-import OB from '@assets/team/OB.png';
-import SK from '@assets/team/SK.png';
-import SS from '@assets/team/SS.png';
-import WO from '@assets/team/WO.png';
 import Checkbox from '@components/common/Checkbox';
-import { useTeamStore } from '@store/useTeamStore';
+import { TEAM_LIST } from '@constants/global';
+import { useTeamStore } from '@store/.';
 import { styles } from './styles';
 
-const teams = [
-  { team: 'KT', name: 'KT', logo: KT },
-  { team: 'OB', name: '두산', logo: OB },
-  { team: 'SS', name: '삼성', logo: SS },
-  { team: 'LG', name: 'LG', logo: LG },
-  { team: 'WO', name: '키움', logo: WO },
-  { team: 'SK', name: 'SSG', logo: SK },
-  { team: 'LT', name: '롯데', logo: LT },
-  { team: 'NC', name: 'NC', logo: NC },
-  { team: 'HT', name: '기아', logo: HT },
-  { team: 'HH', name: '한화', logo: HH },
-] as const;
+interface Props {
+  onChangeTeam: React.ChangeEventHandler<HTMLInputElement>;
+}
 
-export type Teams = typeof teams[number]['team'];
-
-export function TeamList() {
+export function TeamList({ onChangeTeam }: Props) {
   const myTeams = useTeamStore(state => state.myTeams);
-  const addMyTeam = useTeamStore(state => state.addMyTeam);
-  const removeMyTeam = useTeamStore(state => state.removeMyTeam);
-
-  function onChangeTeam(
-    e: React.ChangeEvent<HTMLInputElement & { value: Teams }>
-  ) {
-    if (e.target.checked) {
-      addMyTeam(e.target.value);
-    } else {
-      removeMyTeam(e.target.value);
-    }
-  }
 
   return (
     <ul css={styles.teamList}>
-      {teams.map(team => (
+      {TEAM_LIST.map(team => (
         <li
           key={team.team}
           css={styles.teamBox}
-          style={{ '--team-logo': `url(${team.logo})` }}
+          style={{ '--team-logo': `url(/images/team/${team.team}.png)` }}
         >
           <Checkbox
             id={team.team}
             name="team"
             value={team.team}
-            checked={myTeams.includes(team.team)}
+            defaultChecked={myTeams.includes(team.team)}
             onChange={onChangeTeam}
             label={team.name}
           />

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -1,13 +1,27 @@
+import { useRef } from 'react';
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
 import { TeamList } from '@components/TeamList';
-import { useModalStore } from '@store/.';
+import { useModalStore, useTeamStore } from '@store/.';
 import { colors } from '@styles/theme';
+import { Team } from '@typings/db';
 import { styles } from './styles';
 
 export default function TeamPicker() {
   const modal = useModalStore(state => state.modal);
   const closeModal = useModalStore(state => state.closeModal);
+  const myTeams = useTeamStore(state => state.myTeams);
+  const changedTeamsRef = useRef(new Set(myTeams));
+
+  function onChangeTeam(
+    e: React.ChangeEvent<HTMLInputElement & { value: Team }>
+  ) {
+    if (e.target.checked) {
+      changedTeamsRef.current?.add(e.target.value);
+    } else {
+      changedTeamsRef.current?.delete(e.target.value);
+    }
+  }
 
   return (
     <Modal modal={modal === 'team-picker'}>
@@ -18,7 +32,7 @@ export default function TeamPicker() {
         </div>
         <div css={styles.modalBody}>
           <form>
-            <TeamList />
+            <TeamList onChangeTeam={onChangeTeam} />
             <Button bgColor={colors.indigo[600]} fullWidth>
               저장
             </Button>

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -1,36 +1,30 @@
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
 import { TeamList } from '@components/TeamList';
-import { useModalStore } from '@store/useModalStore';
+import { useModalStore } from '@store/.';
 import { colors } from '@styles/theme';
 import { styles } from './styles';
 
 export default function TeamPicker() {
-  const { modal, openModal, closeModal } = useModalStore();
-
-  function onClick() {
-    openModal('team-picker');
-  }
+  const modal = useModalStore(state => state.modal);
+  const closeModal = useModalStore(state => state.closeModal);
 
   return (
-    <section css={styles.inner}>
-      <Button onClick={onClick}>팀 선택하기</Button>
-      <Modal modal={modal === 'team-picker'}>
-        <section css={styles.modalWrapper}>
-          <div css={styles.modalHeader}>
-            <h2>팀 선택</h2>
-            <button css={styles.closeButton} onClick={closeModal} />
-          </div>
-          <div css={styles.modalBody}>
-            <form>
-              <TeamList />
-              <Button bgColor={colors.indigo[600]} fullWidth>
-                저장
-              </Button>
-            </form>
-          </div>
-        </section>
-      </Modal>
-    </section>
+    <Modal modal={modal === 'team-picker'}>
+      <section css={styles.modalWrapper}>
+        <div css={styles.modalHeader}>
+          <h2>팀 선택</h2>
+          <button css={styles.closeButton} onClick={closeModal} />
+        </div>
+        <div css={styles.modalBody}>
+          <form>
+            <TeamList />
+            <Button bgColor={colors.indigo[600]} fullWidth>
+              저장
+            </Button>
+          </form>
+        </div>
+      </section>
+    </Modal>
   );
 }

--- a/src/components/TeamPicker/styles.ts
+++ b/src/components/TeamPicker/styles.ts
@@ -3,19 +3,6 @@ import { mq } from '@styles/mediaQueries';
 import { colors } from '@styles/theme';
 
 export const styles = {
-  inner: css({
-    padding: '10px 20px',
-    backgroundColor: colors.gray[100],
-    textAlign: 'center',
-    h2: {
-      fontSize: '1.6rem',
-      fontWeight: 600,
-    },
-    [mq('lg')]: {
-      width: 1200,
-      margin: '0 auto',
-    },
-  }),
   modalWrapper: css({
     width: '100vw',
     height: '100vh',

--- a/src/constants/global.ts
+++ b/src/constants/global.ts
@@ -1,0 +1,12 @@
+export const TEAM_LIST = [
+  { team: 'KT', name: 'KT' },
+  { team: 'OB', name: '두산' },
+  { team: 'SS', name: '삼성' },
+  { team: 'LG', name: 'LG' },
+  { team: 'WO', name: '키움' },
+  { team: 'SK', name: 'SSG' },
+  { team: 'LT', name: '롯데' },
+  { team: 'NC', name: 'NC' },
+  { team: 'HT', name: '기아' },
+  { team: 'HH', name: '한화' },
+] as const;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,12 +1,12 @@
 import Header from '@components/Header';
-import TeamPicker from '@components/TeamPicker';
+import MyTeams from '@components/MyTeams';
 
 export default function Main() {
   return (
     <>
       <Header />
       <main>
-        <TeamPicker />
+        <MyTeams />
       </main>
     </>
   );

--- a/src/store/useTeamStore.ts
+++ b/src/store/useTeamStore.ts
@@ -1,17 +1,10 @@
 import create from 'zustand';
-import { Teams } from '@components/TeamList';
+import { Team } from '@typings/db';
 
 interface TeamState {
-  myTeams: Teams[];
-  addMyTeam(team: Teams): void;
-  removeMyTeam(team: Teams): void;
+  myTeams: Team[];
 }
 
-export const useTeamStore = create<TeamState>()(set => ({
+export const useTeamStore = create<TeamState>()(() => ({
   myTeams: [],
-  addMyTeam: team => set(state => ({ myTeams: state.myTeams.concat(team) })),
-  removeMyTeam: team =>
-    set(state => ({
-      myTeams: state.myTeams.filter(myTeam => myTeam !== team),
-    })),
 }));

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -1,6 +1,10 @@
+import { TEAM_LIST } from '@constants/global';
+
 export interface User {
   id: number;
   email: string;
   nickname: string;
   provider: string | null;
 }
+
+export type Team = typeof TEAM_LIST[number]['team'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
       "@utils/*": ["src/utils/*"],
       "@typings/*": ["src/typings/*"],
       "@styles/*": ["src/styles/*"],
-      "@assets/*": ["src/assets/*"]
+      "@assets/*": ["src/assets/*"],
+      "@constants/*": ["src/constants/*"]
     },
     "outDir": "build",
     "target": "es5",


### PR DESCRIPTION
## What is this PR?

#23

## Changes

- 로그인 상태에만 팀 선택 기능 오픈
- 팀 선택 기능 비제어 컴포넌트로 관리하도록 변경

상태로 체크박스 선택 상태를 관리하게 되면, 저장 버튼을 누르지 않고 모달을 닫을 때 상태가 유지되는 문제가 남아있음.
모달을 닫을 때, 선택 상태를 초기화할 수 있는 방법이 존재하지만, 모달 외부 클릭시에는 적용이 불가능함.

따라서 상태로 직접 관리하지 않고,
`onChange` 이벤트에서 현재 `checked` 상태만 가져와서 `ref` 객체에 저장하여 사용하도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 저장 버튼 누르지 않고 모달을 닫으면, 상태가 저장되지 않는 것 확인.
- [x] 저장 버튼 누르면, 선택한 팀 상태에 저장되는 것 확인 (커밋 내역에 관련 코드 없으며 테스트만 함.  추가 예정) 

## Etc

`ref` 객체에 담을 값을 배열로 할까 하다가, 잘 안 써본 `Set` 을 활용함.
