### PR TITLE
Refactor: 로그인 컴포넌트 내부로 모달 상태 이동

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,7 +6,6 @@ import { User } from '@typings/db';
 import { styles } from './styles';
 
 export default function Header() {
-  const modal = useModalStore(state => state.modal);
   const openModal = useModalStore(state => state.openModal);
   const closeModal = useModalStore(state => state.closeModal);
   const user = useUserStore(state => state.user);
@@ -33,7 +32,7 @@ export default function Header() {
         ) : (
           <Button onClick={onClickLogin}>로그인</Button>
         )}
-        <Login modal={modal === 'login'} onSuccess={successLogin} />
+        <Login onSuccess={successLogin} />
       </div>
     </header>
   );

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -4,7 +4,7 @@ import KakaoLoginIcon from '@assets/kakao-login.svg';
 import NaverLoginIcon from '@assets/naver-login.svg';
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
-import { baseURL } from '@services/index';
+import { BASE_URL } from '@constants/global';
 import { useModalStore } from '@store/.';
 import { colors } from '@styles/theme';
 import { User } from '@typings/db';
@@ -84,7 +84,7 @@ export default function Login({ modal, onSuccess }: Props) {
     const left = document.body.offsetWidth / 2 - 250;
     const top = document.body.offsetHeight / 2 - 250;
 
-    const url = `${baseURL}/auth/${provider}`;
+    const url = `${BASE_URL}/auth/${provider}`;
     const target = 'authentication';
     const features = `left=${left},top=${top},width=500,height=500`;
 

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -11,7 +11,6 @@ import { User } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
-  modal: boolean;
   onSuccess(user: User): void;
 }
 
@@ -54,7 +53,8 @@ const providers = [
   },
 ] as const;
 
-export default function Login({ modal, onSuccess }: Props) {
+export default function Login({ onSuccess }: Props) {
+  const modal = useModalStore(state => state.modal);
   const closeModal = useModalStore(state => state.closeModal);
   const newWindowRef = useRef<Window | null>();
   const prevWindowUrlRef = useRef<string>();
@@ -108,7 +108,7 @@ export default function Login({ modal, onSuccess }: Props) {
   }, [receiveMessage]);
 
   return (
-    <Modal modal={modal}>
+    <Modal modal={modal === 'login'}>
       <section css={styles.modalWrapper}>
         <div css={styles.modalHeader}>
           <h2>로그인</h2>

--- a/src/constants/global.ts
+++ b/src/constants/global.ts
@@ -10,3 +10,5 @@ export const TEAM_LIST = [
   { team: 'HT', name: '기아' },
   { team: 'HH', name: '한화' },
 ] as const;
+
+export const BASE_URL = 'http://localhost:8080/api';

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,5 @@
 import { User } from '@typings/db';
-import { authAPI } from '.';
+import { httpClient } from '.';
 
 interface AuthResponse {
   success: boolean;
@@ -8,9 +8,9 @@ interface AuthResponse {
 }
 
 export function login() {
-  return authAPI.get<AuthResponse>('/login');
+  return httpClient.get<AuthResponse>('/auth/login');
 }
 
 export function logout() {
-  return authAPI.post<Omit<AuthResponse, 'user'>>('/logout');
+  return httpClient.post<Omit<AuthResponse, 'user'>>('/auth/logout');
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
+import { BASE_URL } from '@constants/global';
 
-export const baseURL = 'http://localhost:8080/api';
-
-export const authAPI = axios.create({
-  baseURL: `${baseURL}/auth`,
+export const httpClient = axios.create({
+  baseURL: BASE_URL,
   withCredentials: true,
 });


### PR DESCRIPTION
## What is this PR?

로그인 컴포넌트 일부 잘못 작성했던 코드 수정

## Changes

- 로그인 컴포넌트 내부로 모달 상태 이동
부모 컴포넌트에서 모달 값을 받아 로그인 컴포넌트에서 props로 전달할 필요 없이,
모달 상태를 로그인 컴포넌트가 직접 구독하여 로그인 모달창이 열리도록 함.

- axios instance 명칭 변경
authAPI, teamAPI 이런 식으로 인스턴스를 나누는 방식을 처음에 고려했다가 통일된 인스턴스로 수정함.

- baseURL → BASE_URL로 변수명 변경 후, 상수 파일로 이동

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음
