### PR TITLE
Design: 체크하는 팀 선택 박스 정렬

### DIFF
--- a/src/components/TeamPickerList/index.tsx
+++ b/src/components/TeamPickerList/index.tsx
@@ -16,20 +16,20 @@ export default function TeamPickerList({ teams, onChangeTeam }: Props) {
   return (
     <ul css={styles.teamList}>
       {TEAM_LIST.map(team => (
-        <li
-          key={team.team}
-          css={styles.teamBox}
-          style={{ '--team-logo': `url(/images/team/${team.team}.png)` }}
-        >
-          <Checkbox
-            id={team.team}
-            name="team"
-            value={team.team}
-            checked={getTeamIsChecked(team.team)}
-            onChange={onChangeTeam}
-            label={team.name}
-            data-value={team.name}
-          />
+        <li key={team.team}>
+          <span
+            style={{ '--team-logo': `url('/images/team/${team.team}.png')` }}
+          >
+            <Checkbox
+              id={team.team}
+              name="team"
+              value={team.team}
+              checked={getTeamIsChecked(team.team)}
+              onChange={onChangeTeam}
+              label={team.name}
+              data-value={team.name}
+            />
+          </span>
         </li>
       ))}
     </ul>

--- a/src/components/TeamPickerList/styles.ts
+++ b/src/components/TeamPickerList/styles.ts
@@ -6,37 +6,40 @@ export const styles = {
   teamList: css({
     display: 'flex',
     flexWrap: 'wrap',
-  }),
-  teamBox: css({
-    width: '40%',
-    height: 150,
-    margin: '2% 5%',
-    border: `1px solid ${colors.gray[300]}`,
-    borderRadius: 4,
-    textAlign: 'center',
-    backgroundImage: 'var(--team-logo)',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: '50% 35%',
-    fontWeight: 600,
-    label: {
+    marginLeft: '-1rem',
+    li: {
+      width: '50%',
+      height: 150,
+      marginBottom: '1rem',
+      [mq('xs')]: {
+        width: '20%',
+      },
+    },
+    span: {
       position: 'relative',
+      display: 'block',
+      height: '100%',
+      margin: '0 0 1rem 1rem',
+      borderRadius: 4,
+      border: `1px solid ${colors.gray[300]}`,
+      backgroundImage: 'var(--team-logo)',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: '50% 35%',
+      backgroundSize: '70px 50px',
+    },
+    label: {
+      height: '100%',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'end',
-      height: '100%',
+      paddingBottom: '1.25rem',
+      fontWeight: 600,
       cursor: 'pointer',
-    },
-    span: {
-      paddingBottom: 20,
     },
     input: {
       position: 'absolute',
       top: 5,
       right: 5,
-    },
-    [mq('sm')]: {
-      width: '16%',
-      margin: '2%',
     },
   }),
 };

--- a/src/components/common/Checkbox/index.tsx
+++ b/src/components/common/Checkbox/index.tsx
@@ -9,9 +9,9 @@ export default function Checkbox({
   ...props
 }: React.ComponentPropsWithRef<'input'> & React.PropsWithChildren<Props>) {
   return (
-    <label htmlFor={props.id}>
+    <>
+      <label htmlFor={props.id}>{label}</label>
       <input type="checkbox" {...props} />
-      {label && <span>{label}</span>}
-    </label>
+    </>
   );
 }


### PR DESCRIPTION
## What is this PR?

#38

## Changes

양 끝에 위치하는 박스에도 좌우 margin이 적용되던 것 삭제하기 위해,
li 요소의 width 값을 나누고 싶은 너비만큼 주고, ex) 20%, 50%
그 안에 새로운 래핑 요소를 만들어, margin 값을 적용함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 변경 전 | <img src="https://user-images.githubusercontent.com/37580351/192133373-a51ea713-6bc4-4298-9f5e-85cd40fa71f8.png" width="300" /> <img src="https://user-images.githubusercontent.com/37580351/192133417-5344de7c-966e-46b3-ae06-e08e2ad183f0.png" width="300" /> |
| 변경 후 | <img src="https://user-images.githubusercontent.com/37580351/192133376-6873b563-5495-4c72-9881-f15f2455e838.png" width="300" /> <img src="https://user-images.githubusercontent.com/37580351/192133419-f4575afe-7ed8-4574-a1ef-e150eddc97a7.png" width="300" />

## Test Checklist

없음

## Etc

없음