### PR TITLE
Design: 모달 컴포넌트 레이아웃 변경

### DIFF
--- a/src/components/Login/styles.ts
+++ b/src/components/Login/styles.ts
@@ -1,22 +1,18 @@
 import { css } from '@emotion/react';
-import { mq } from '@styles/mediaQueries';
 import { colors } from '@styles/theme';
 
 export const styles = {
   modalWrapper: css({
-    width: '100vw',
-    height: '100vh',
-    [mq('xs')]: {
-      width: 360,
-      height: 'auto',
-    },
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
   }),
   modalHeader: css({
     display: 'flex',
     justifyContent: 'space-between',
     backgroundColor: colors.gray[300],
     borderRadius: '4px 4px 0 0',
-    padding: '1.25rem',
+    padding: '1rem',
     h2: {
       fontFamily: 'UtoBalsamTint',
       fontWeight: 600,
@@ -45,7 +41,7 @@ export const styles = {
     },
   }),
   modalBody: css({
-    padding: '1.25rem',
+    padding: '1rem',
   }),
   providerList: css({
     li: {

--- a/src/components/TeamPicker/styles.ts
+++ b/src/components/TeamPicker/styles.ts
@@ -1,21 +1,16 @@
 import { css } from '@emotion/react';
-import { mq } from '@styles/mediaQueries';
 import { colors } from '@styles/theme';
 
 export const styles = {
   modalWrapper: css({
-    width: '100vw',
-    height: '100vh',
-    overflowY: 'auto',
-    [mq('sm')]: {
-      width: 700,
-      height: 'auto',
-    },
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
   }),
   modalHeader: css({
     display: 'flex',
     justifyContent: 'space-between',
-    padding: '1.25rem',
+    padding: '1rem',
     backgroundColor: colors.gray[300],
     borderRadius: '4px 4px 0 0',
     textAlign: 'center',
@@ -48,6 +43,7 @@ export const styles = {
     },
   }),
   modalBody: css({
-    padding: '1.25rem',
+    padding: '1rem',
+    overflowY: 'auto',
   }),
 };

--- a/src/components/common/Modal/styles.ts
+++ b/src/components/common/Modal/styles.ts
@@ -1,4 +1,5 @@
 import { css, keyframes } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
 import { colors } from '@styles/theme';
 
 const modalFadeIn = keyframes({
@@ -29,18 +30,23 @@ export const styles = {
       bottom: 0,
       left: 0,
       right: 0,
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
       backgroundColor: 'rgba(0,0,0,0.4)',
       animationName: modal ? modalFadeIn : modalFadeOut,
       animationDuration: '0.6s',
     }),
   modalContainer: (modal: boolean) =>
     css({
+      display: 'flex',
+      maxHeight: 'calc(100% - 1rem)',
+      margin: '0.5rem',
       backgroundColor: colors.white,
       borderRadius: 4,
       animationName: modal ? modalBoxSlideDown : modalBoxSlideUp,
       animationDuration: '0.6s',
+      [mq('xs')]: {
+        maxWidth: 500,
+        maxHeight: 'calc(100% - 16rem)',
+        margin: '8rem auto',
+      },
     }),
 };


### PR DESCRIPTION
## What is this PR?

#38

## Changes

- 구현하고 싶었던 것
1. 모달 컨텐츠에 header-body-footer가 있다면, body 영역 컨텐츠가 넘치는 경우에만 스크롤 생성.
2. 모바일에서는 되도록 전체 화면 차지, 태블릿 이상에서는 가운데 정렬이 되도록 할 것.

- 기존 코드의 문제점
기존 코드는 overlay 영역에서 모달 컨텐츠를 정가운데로 정렬하기 때문에,
모달의 body 영역에서의 스크롤만 생성하기가 까다로움.
모달 컨텐츠 전체에 스크롤 생성이 가능하지만, 스크롤을 내리게 되면 닫기 버튼이 보이지 않음.
외부 클릭을 통해 닫기가 가능하지만, 명시적으로 닫기 버튼을 보여주는 것이 더 좋음.

- 변경점
모달 컨텐츠를 감싸는 container를 가운데 정렬하는 코드를 삭제하고,
flex를 사용해 bfc를 새로 만들고, max-height, margin 속성을 이용해 화면 크기에 따라 모달의 렌더링 위치를 결정함.
큰 화면에서는 모달의 가운데 정렬이 필요하기 때문에,
margin 값을 크게 주어 위에서부터의 거리를 어느 정도 두는 형식으로 이를 보완함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 화면 크기별로, 모달 컨텐츠 body 영역이 자신의 최대 크기보다 넘칠 때, 스크롤이 생성되는지 확인

## Etc

- 남아있는 이슈
모달 컨텐츠에 따라 컨텐츠 영역의 너비를 자유롭게 사용할 수 없음.
모달 컨텐츠 영역의 슬라이드 애니메이션을 공통 코드로 빼는 과정에서,
너비를 고정하지 않으면 화면 전체를 차지해버려 가운데 정렬이 되지 않는 문제가 발생함.
최대한 너무 크지도, 작지도 않은 모달의 크기를 고려하여 500px로 고정시킴

- [참고 코드](https://www.w3schools.com/bootstrap4/tryit.asp?filename=trybs_modal_scroll2&stacked=h)
