### PR TITLE
Design: 팀 선택창에서 현재 선택한 팀을 순서대로 보여주도록 UI 변경

### DIFF
--- a/src/components/PickTeamList/index.tsx
+++ b/src/components/PickTeamList/index.tsx
@@ -1,0 +1,26 @@
+import { TeamList } from '@typings/db';
+import { styles } from './styles';
+
+interface Props {
+  teams: TeamList;
+}
+
+export default function PickTeamList({ teams }: Props) {
+  if (teams.length == 0) {
+    return <div css={styles.noneTeamList}>선택한 팀이 없습니다.</div>;
+  }
+
+  return (
+    <ul css={styles.teamList}>
+      {teams.map((team, index) => (
+        <li key={team.team}>
+          <button>
+            <em>{index + 1}</em>
+            <img src={`/images/team/${team.team}.png`} alt={team.name} />
+            <span>{team.name}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/PickTeamList/styles.ts
+++ b/src/components/PickTeamList/styles.ts
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  noneTeamList: css({
+    minHeight: 400,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: '1rem',
+    borderRadius: 4,
+    backgroundColor: colors.gray[100],
+    textAlign: 'center',
+  }),
+  teamList: css({
+    height: 400,
+    marginBottom: '1rem',
+    backgroundColor: colors.gray[100],
+    borderRadius: 4,
+    li: {
+      height: 40,
+      borderBottom: `1px solid ${colors.gray[100]}`,
+      backgroundColor: colors.white,
+    },
+    button: {
+      display: 'flex',
+      alignItems: 'center',
+      width: '100%',
+      height: '100%',
+    },
+    em: {
+      flexBasis: 20,
+      fontStyle: 'italic',
+      fontWeight: 600,
+      fontSize: '1.4rem',
+      color: colors.indigo[600],
+    },
+    img: {
+      width: 40,
+      height: 30,
+      margin: '0 1rem',
+    },
+  }),
+};

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -26,9 +26,7 @@ export default function TeamPicker() {
     }
   }
 
-  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-
+  function savePickedTeams() {
     const isChanged =
       myTeams.length !== pickedTeams.length ||
       (pickedTeams.length > 0 &&
@@ -51,12 +49,14 @@ export default function TeamPicker() {
       </div>
       <div css={styles.modalBody}>
         <PickTeamList teams={pickedTeams} />
-        <form onSubmit={onSubmit}>
-          <TeamPickerList teams={pickedTeams} onChangeTeam={onChangeTeam} />
-          <Button bgColor={colors.indigo[600]} fullWidth>
-            저장
-          </Button>
-        </form>
+        <TeamPickerList teams={pickedTeams} onChangeTeam={onChangeTeam} />
+        <Button
+          bgColor={colors.indigo[600]}
+          fullWidth
+          onClick={savePickedTeams}
+        >
+          저장
+        </Button>
       </div>
     </section>
   );

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@components/common/Button';
+import PickTeamList from '@components/PickTeamList';
 import TeamPickerList from '@components/TeamPickerList';
 import { useModalStore, useTeamStore } from '@store/.';
 import { colors } from '@styles/theme';
@@ -49,6 +50,7 @@ export default function TeamPicker() {
         <button css={styles.closeButton} onClick={closeModal} />
       </div>
       <div css={styles.modalBody}>
+        <PickTeamList teams={changedTeams} />
         <form onSubmit={onSubmit}>
           <TeamPickerList teams={changedTeams} onChangeTeam={onChangeTeam} />
           <Button bgColor={colors.indigo[600]} fullWidth>

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -11,7 +11,7 @@ export default function TeamPicker() {
   const closeModal = useModalStore(state => state.closeModal);
   const myTeams = useTeamStore(state => state.myTeams);
   const changeMyTeams = useTeamStore(state => state.changeMyTeams);
-  const [changedTeams, setChangedTeams] = useState(myTeams);
+  const [pickedTeams, setPickedTeams] = useState(myTeams);
 
   function onChangeTeam(
     e: React.ChangeEvent<
@@ -20,9 +20,9 @@ export default function TeamPicker() {
   ) {
     const team = { team: e.target.value, name: e.target.dataset.value };
     if (e.target.checked) {
-      setChangedTeams(prev => prev.concat(team));
+      setPickedTeams(prev => prev.concat(team));
     } else {
-      setChangedTeams(prev => prev.filter(exTeam => exTeam.team !== team.team));
+      setPickedTeams(prev => prev.filter(exTeam => exTeam.team !== team.team));
     }
   }
 
@@ -30,14 +30,14 @@ export default function TeamPicker() {
     e.preventDefault();
 
     const isChanged =
-      myTeams.length !== changedTeams.length ||
-      (changedTeams.length > 0 &&
-        changedTeams.some(changedTeam => {
-          return myTeams.findIndex(exTeam => exTeam == changedTeam) == -1;
+      myTeams.length !== pickedTeams.length ||
+      (pickedTeams.length > 0 &&
+        pickedTeams.some(pickedTeam => {
+          return myTeams.findIndex(exTeam => exTeam == pickedTeam) == -1;
         }));
 
     if (isChanged) {
-      changeMyTeams(changedTeams);
+      changeMyTeams(pickedTeams);
     } else {
       closeModal();
     }
@@ -50,9 +50,9 @@ export default function TeamPicker() {
         <button css={styles.closeButton} onClick={closeModal} />
       </div>
       <div css={styles.modalBody}>
-        <PickTeamList teams={changedTeams} />
+        <PickTeamList teams={pickedTeams} />
         <form onSubmit={onSubmit}>
-          <TeamPickerList teams={changedTeams} onChangeTeam={onChangeTeam} />
+          <TeamPickerList teams={pickedTeams} onChangeTeam={onChangeTeam} />
           <Button bgColor={colors.indigo[600]} fullWidth>
             저장
           </Button>


### PR DESCRIPTION
## What is this PR?

close #38

## Changes

- 현재 선택한 팀의 순서가 표시될 수 있도록 ui 변경
- 픽한 팀 리스트와 체크 리스트를 동일한 위치에 렌더링 시키고 싶어서 form 요소 삭제.
form 요소 안에 픽한 팀 리스트를 넣게 되면 그 안의 버튼 요소를 따로 제어해줘야 해서 불편함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 변경한 화면 | ![제목 없음](https://user-images.githubusercontent.com/37580351/192249329-4c82dc4a-8f1e-48af-a3bc-a13e5901f5a8.png)   |


## Test Checklist

없음

## Etc

순서를 바꾸려고 할 때는 항상 선택 팀을 토글해서 리스트에서 지워야 하므로 아직은 반쪽자리 기능.
사용자가 팀을 직접 드래그해서 옮길 수 있는 기능을 추후 추가할 것.
