### PR TITLE
Fix: 모달 컨텐츠 박스의 최대 높이를 뷰포트보다 작게 지정 

### DIFF
--- a/src/components/Login/styles.ts
+++ b/src/components/Login/styles.ts
@@ -13,6 +13,7 @@ export const styles = {
     [mq('xs')]: {
       width: 360,
       margin: 'auto',
+      maxHeight: 'calc(100% - 4rem)',
     },
   }),
   modalHeader: css({

--- a/src/components/TeamPicker/styles.ts
+++ b/src/components/TeamPicker/styles.ts
@@ -12,6 +12,7 @@ export const styles = {
     [mq('xs')]: {
       width: 500,
       margin: 'auto',
+      maxHeight: 'calc(100% - 4rem)',
     },
   }),
   modalHeader: css({


### PR DESCRIPTION
## What is this PR?

close #45

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

가운데 정렬을 하기 위해 `margin: auto` 값을 무작정 전달하면,
컨텐츠 박스의 크기가 뷰포트 크기보다 더 클 때 스크롤이 발생하지 않음

뷰포트 내에서 일정 크기를 뺀 값을 최대 크기로 지정해놓으면,
1. 최대 크기를 넘치는 컨텐츠 박스는 최대 크기로 생성되고 그 안에서 스크롤을 만들 수 있고,
2. 넘치지 않으면 컨텐츠 박스에 맞춰 화면 내에서 가로 세로 가운데 정렬이 만들어짐.

1번의 경우는 TeamPicker 컴포넌트,
2번의 경우는 Login 컴포넌트

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 모달 컨텐츠가 최대 크기를 넘치는 경우 |  ![제목 없음](https://user-images.githubusercontent.com/37580351/192437542-7dbc91a8-2bdd-4301-bd4a-e9cabf5d1b6b.png) |
| 모달 컨텐츠가 최대 크기를 넘치지 않는 경우 | ![로그인](https://user-images.githubusercontent.com/37580351/192437581-69bd635c-f71d-4266-b633-412259f9a479.png) |

## Test Checklist

없음

## Etc

- 스크린샷은 오류를 발생시켰던 화면만 첨부했지만,
실제로 개발자 도구에 있는 디바이스 크기 별로 테스트 했을 때 동일하게 화면에 표시됨.

- 100% 대신 뷰포트 높이를 나타내는 100vh를 전달해도 똑같이 표시됨.

