### PR TITLE
Fix: 훅 대신 overlay 클릭 함수 생성하여 모달 외부 클릭 닫기 허용

### DIFF
--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import useDelayUnmount from '@hooks/useDelayUnmount';
-import useDetectOutsideClick from '@hooks/useDetectOutsideClick';
+import useElement from '@hooks/useElement';
 import { useModalStore } from '@store/.';
 import { styles } from './styles';
 
@@ -16,8 +16,22 @@ export default function Modal({
 }: React.PropsWithChildren<Props>) {
   const closeModal = useModalStore(state => state.closeModal);
   const isMounted = useDelayUnmount(modal);
-  const setModalRef = useDetectOutsideClick(isMounted, closeModal);
+  const [modalRef, setModalRef] = useElement();
   const scrollBarWidth = useRef(window.innerWidth - document.body.clientWidth);
+
+  function onClickOverlay(e: React.MouseEvent) {
+    if (modalRef.current && e.target instanceof HTMLElement) {
+      if (e.target.contains(modalRef.current)) {
+        closeModal();
+      }
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') {
+      closeModal();
+    }
+  }
 
   useEffect(() => {
     const scrollable = window.innerHeight !== document.body.scrollHeight;
@@ -36,7 +50,13 @@ export default function Modal({
   if (!isMounted) return null;
 
   return createPortal(
-    <div css={styles.modalOverlay(modal)}>
+    <div
+      css={styles.modalOverlay(modal)}
+      onClick={onClickOverlay}
+      onKeyDown={onKeyDown}
+      role="button"
+      tabIndex={0}
+    >
       <div css={styles.modalDialog(modal)} ref={setModalRef}>
         {children}
       </div>


### PR DESCRIPTION
## What is this PR?

close #47 

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Changes

- 기존에 훅을 사용한 이벤트를 제거하고, 모달 오버레이 영역에 직접 클릭 이벤트 추가
- 모달을 사용하는 곳에 크기와 위치에 대한 자유도를 넘겨주면서,
공통되는 모달 컨텐츠 박스의 래핑 박스가 화면 전체를 차지해버리기 때문에
기존의 훅을 사용해서 만든 이벤트는 더이상 모달 외부 클릭을 탐지하지 못함.
따라서, 오버레이 영역에 클릭 이벤트를 추가하여 타겟이 모달 래핑 박스를 포함하면 닫히도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| desktop |  ![Animation](https://user-images.githubusercontent.com/37580351/192938825-9f36779b-dd3a-499e-9c26-7db1fa90c401.gif)  |

## Test Checklist

- [x] 모달창 외부 클릭 감지 확인

## Etc

디자인 변경했을 때, 다른 기능들에 대해 테스트를 하지 않아 발생한 버그.
