### PR TITLE
Feat: 등록할 티켓 날짜 선택 기능 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Authenticated from '@pages/Authenticated';
 import Layout from '@pages/Layout';
 import Main from '@pages/Main';
+import TicketRegister from '@pages/TicketRegister';
 
 export default function Router() {
   return (
@@ -9,9 +10,7 @@ export default function Router() {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<Main />} />
-          <Route path="register">
-            <Route path=":team" />
-          </Route>
+          <Route path="register" element={<TicketRegister />} />
         </Route>
         <Route path="authenticated" element={<Authenticated />} />
       </Routes>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,12 +1,18 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Authenticated from '@pages/Authenticated';
+import Layout from '@pages/Layout';
 import Main from '@pages/Main';
 
 export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Main />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<Main />} />
+          <Route path="register">
+            <Route path=":team" />
+          </Route>
+        </Route>
         <Route path="authenticated" element={<Authenticated />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/SetMatchDate/index.tsx
+++ b/src/components/SetMatchDate/index.tsx
@@ -51,10 +51,12 @@ export default function SetMatchDate() {
 
   function onChangeMonth(month: number) {
     const newDates = getDates(matchDate.year, month - 1);
+    const hasFewerDates = newDates.length < matchDate.date;
     setDates(newDates);
     setMatchDate(prev => ({
       ...prev,
       month,
+      date: hasFewerDates ? 1 : prev.date,
     }));
   }
 

--- a/src/components/SetMatchDate/index.tsx
+++ b/src/components/SetMatchDate/index.tsx
@@ -36,13 +36,13 @@ const { years, months } = getMatchCalendar();
 
 export default function SetMatchDate() {
   const [matchDate, setMatchDate] = useState({ year: 0, month: 0, date: 0 });
-  const [dates, setDates] = useState(() => {
-    return getDates(matchDate.year, matchDate.month - 1);
-  });
+  const [dates, setDates] = useState<number[]>([]);
 
   function onChangeYear(year: number) {
-    const newDates = getDates(year, matchDate.month - 1);
-    setDates(newDates);
+    if (matchDate.month != 0) {
+      const newDates = getDates(year, matchDate.month - 1);
+      setDates(newDates);
+    }
     setMatchDate(prev => ({
       ...prev,
       year,

--- a/src/components/SetMatchDate/index.tsx
+++ b/src/components/SetMatchDate/index.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import Dropdown from '@components/common/Dropdown';
+import { styles } from './styles';
+
+function getMatchCalendar() {
+  function getMatchYears() {
+    const currentYear = new Date().getFullYear();
+    const matchStartYear = 1982;
+    const years: number[] = [];
+
+    for (let i = currentYear; i >= matchStartYear; i--) {
+      years.push(i);
+    }
+
+    return years;
+  }
+
+  return {
+    years: getMatchYears(),
+    months: [3, 4, 5, 6, 7, 8, 9, 10, 11],
+  };
+}
+
+function getDates(year: number, month: number) {
+  const dates: number[] = [];
+  const lastDayOfMonth = new Date(year, month + 1, 0).getDate();
+
+  for (let i = 1; i <= lastDayOfMonth; i++) {
+    dates.push(i);
+  }
+
+  return dates;
+}
+
+const { years, months } = getMatchCalendar();
+
+export default function SetMatchDate() {
+  const [matchDate, setMatchDate] = useState({ year: 0, month: 0, date: 0 });
+  const [dates, setDates] = useState(() => {
+    return getDates(matchDate.year, matchDate.month - 1);
+  });
+
+  function onChangeYear(year: number) {
+    const newDates = getDates(year, matchDate.month - 1);
+    setDates(newDates);
+    setMatchDate(prev => ({
+      ...prev,
+      year,
+    }));
+  }
+
+  function onChangeMonth(month: number) {
+    const newDates = getDates(matchDate.year, month - 1);
+    setDates(newDates);
+    setMatchDate(prev => ({
+      ...prev,
+      month,
+    }));
+  }
+
+  function onChangeDate(date: number) {
+    setMatchDate(prev => ({ ...prev, date }));
+  }
+
+  return (
+    <div css={styles.wrapper}>
+      <h3>경기 날짜를 선택하세요</h3>
+      <div css={styles.selectCalendar}>
+        <Dropdown
+          list={years}
+          selectedValue={matchDate.year || '년도'}
+          onChangeValue={onChangeYear}
+        />
+        <Dropdown
+          list={months}
+          selectedValue={matchDate.month || '월'}
+          onChangeValue={onChangeMonth}
+        />
+        <Dropdown
+          list={dates}
+          selectedValue={matchDate.date || '일'}
+          onChangeValue={onChangeDate}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/SetMatchDate/styles.ts
+++ b/src/components/SetMatchDate/styles.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+  wrapper: css({
+    h3: {
+      padding: '1rem 0',
+    },
+  }),
+  selectCalendar: css({
+    display: 'flex',
+  }),
+};

--- a/src/components/StadiumList/index.tsx
+++ b/src/components/StadiumList/index.tsx
@@ -1,8 +1,16 @@
 import { Link } from 'react-router-dom';
 import { TEAM_LIST } from '@constants/global';
+import { useModalStore } from '@store/useModalStore';
+import { Team } from '@typings/db';
 import { styles } from './styles';
 
+function getAwayTeams(team: Team) {
+  return TEAM_LIST.filter(teamInfo => teamInfo.team !== team);
+}
+
 export default function StadiumList() {
+  const closeModal = useModalStore(state => state.closeModal);
+
   return (
     <ul css={styles.stadiumSelect}>
       {TEAM_LIST.map(team => (
@@ -14,7 +22,16 @@ export default function StadiumList() {
           >
             <em>{team.name}</em>
             <em>{team.stadium}</em>
-            <Link to={`/register/${team.team}`}>티켓 등록</Link>
+            <Link
+              to="/register"
+              state={{
+                homeTeam: { ...team },
+                awayTeams: getAwayTeams(team.team),
+              }}
+              onClick={closeModal}
+            >
+              티켓 등록
+            </Link>
           </span>
         </li>
       ))}

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useDetectOutsideClick from '@hooks/useDetectOutsideClick';
 import { styles } from './styles';
 
 interface Props {
@@ -15,6 +16,7 @@ export default function Dropdown({
   width = '100%',
 }: Props) {
   const [visible, setVisible] = useState(false);
+  const setDropdownRef = useDetectOutsideClick(visible, toggleDropdownVisible);
 
   function toggleDropdownVisible() {
     setVisible(prev => !prev);
@@ -27,7 +29,11 @@ export default function Dropdown({
   }
 
   return (
-    <div css={styles.dropdownWrapper} style={{ '--dropdown-width': width }}>
+    <div
+      css={styles.dropdownWrapper}
+      style={{ '--dropdown-width': width }}
+      ref={setDropdownRef}
+    >
       <button
         onClick={toggleDropdownVisible}
         css={styles.toggleButton(visible)}

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -31,6 +31,7 @@ export default function Dropdown({
       <button
         onClick={toggleDropdownVisible}
         css={styles.toggleButton(visible)}
+        disabled={list.length == 0}
       >
         {selectedValue}
       </button>

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { styles } from './styles';
+
+interface Props {
+  list: string[] | number[];
+  selectedValue: string | number;
+  onChangeValue(value: string | number): void;
+  width?: string;
+}
+
+export default function Dropdown({
+  selectedValue,
+  list,
+  onChangeValue,
+  width = '100%',
+}: Props) {
+  const [visible, setVisible] = useState(false);
+
+  function toggleDropdownVisible() {
+    setVisible(prev => !prev);
+  }
+
+  function onChange(value: string | number) {
+    setVisible(false);
+    if (value === selectedValue) return;
+    onChangeValue(value);
+  }
+
+  return (
+    <div css={styles.dropdownWrapper} style={{ '--dropdown-width': width }}>
+      <button
+        onClick={toggleDropdownVisible}
+        css={styles.toggleButton(visible)}
+      >
+        {selectedValue}
+      </button>
+      <ul css={styles.dropdownList(visible)}>
+        {list.map(value => (
+          <li key={value}>
+            <button
+              onClick={() => onChange(value)}
+              css={styles.value(value === selectedValue)}
+            >
+              {value}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/common/Dropdown/styles.ts
+++ b/src/components/common/Dropdown/styles.ts
@@ -1,0 +1,60 @@
+import { css } from '@emotion/react';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  dropdownWrapper: css({
+    position: 'relative',
+    width: 'var(--dropdown-width)',
+  }),
+  toggleButton: (visible: boolean) =>
+    css({
+      position: 'relative',
+      width: '100%',
+      borderRadius: 6,
+      boxShadow: '1px 1px 10px rgba(0,0,0,0.1)',
+      textAlign: 'inherit',
+      height: 40,
+      padding: '0 1rem',
+      '&:after': {
+        content: '""',
+        position: 'absolute',
+        top: '50%',
+        right: '1rem',
+        padding: 3,
+        border: `solid ${colors.black}`,
+        borderWidth: '0 0 2px 2px',
+        transform: visible
+          ? 'rotate(135deg)'
+          : 'rotate(-45deg) translateY(-50%)',
+        transition: '.5s',
+      },
+    }),
+  dropdownList: (visible: boolean) =>
+    css({
+      zIndex: 100,
+      position: 'absolute',
+      top: 45,
+      left: 0,
+      width: '100%',
+      height: 200,
+      overflowY: 'auto',
+      visibility: visible ? 'visible' : 'hidden',
+      opacity: visible ? 1 : 0,
+      transform: visible ? 'translateY(0)' : 'translateY(-20px)',
+      transition: '.5s',
+      boxShadow: '1px 1px 10px rgba(0,0,0,0.1)',
+      borderRadius: 6,
+      background: colors.white,
+      button: {
+        width: '100%',
+        height: 40,
+        padding: '0 1rem',
+        textAlign: 'inherit',
+      },
+    }),
+  value: (selected: boolean) =>
+    css({
+      background: selected ? colors.gray[100] : 'transparent',
+      fontWeight: selected ? 600 : 400,
+    }),
+};

--- a/src/components/common/Dropdown/styles.ts
+++ b/src/components/common/Dropdown/styles.ts
@@ -15,6 +15,10 @@ export const styles = {
       textAlign: 'inherit',
       height: 40,
       padding: '0 1rem',
+      '&:disabled': {
+        opacity: '.5',
+        cursor: 'not-allowed',
+      },
       '&:after': {
         content: '""',
         position: 'absolute',

--- a/src/pages/Layout/index.tsx
+++ b/src/pages/Layout/index.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import Header from '@components/Header';
+import { styles } from './styles';
+
+export default function Layout() {
+  return (
+    <>
+      <Header />
+      <main css={styles.inner}>
+        <Outlet />
+      </main>
+    </>
+  );
+}

--- a/src/pages/Layout/styles.ts
+++ b/src/pages/Layout/styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  inner: css({
+    [mq('lg')]: {
+      width: 1200,
+      margin: '0 auto',
+    },
+  }),
+};

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,6 +1,5 @@
 import Button from '@components/common/Button';
 import Modal from '@components/common/Modal';
-import Header from '@components/Header';
 import MyTeamList from '@components/MyTeamList';
 import TeamPicker from '@components/TeamPicker';
 import { useModalStore } from '@store/useModalStore';
@@ -19,21 +18,18 @@ export default function Main() {
 
   return (
     <>
-      <Header />
-      <main css={styles.inner}>
-        <section>
-          <header css={styles.title}>
-            <h2>나의 팀</h2>
-            <Button onClick={addTeams} bgColor={colors.indigo[600]}>
-              팀 추가
-            </Button>
-            <Modal modal={modal === 'team-picker'}>
-              <TeamPicker />
-            </Modal>
-          </header>
-          <MyTeamList />
-        </section>
-      </main>
+      <section>
+        <header css={styles.title}>
+          <h2>나의 팀</h2>
+          <Button onClick={addTeams} bgColor={colors.indigo[600]}>
+            팀 추가
+          </Button>
+          <Modal modal={modal === 'team-picker'}>
+            <TeamPicker />
+          </Modal>
+        </header>
+        <MyTeamList />
+      </section>
     </>
   );
 }

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,0 +1,9 @@
+import { styles } from './styles';
+
+export default function TicketRegister() {
+  return (
+    <section css={styles.wrapper}>
+      <h2>티켓 등록</h2>
+    </section>
+  );
+}

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,9 +1,11 @@
+import SetMatchDate from '@components/SetMatchDate';
 import { styles } from './styles';
 
 export default function TicketRegister() {
   return (
     <section css={styles.wrapper}>
       <h2>티켓 등록</h2>
+      <SetMatchDate />
     </section>
   );
 }

--- a/src/pages/TicketRegister/styles.ts
+++ b/src/pages/TicketRegister/styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+  wrapper: css({
+    padding: 20,
+    h2: {
+      fontSize: '1.6rem',
+      fontWeight: 600,
+    },
+  }),
+};


### PR DESCRIPTION
## What is this PR?

#51

## Changes

- 사용자가 티켓에 대한 많은 정보를 입력하는 것을 최소화하기 위해,
일부 정보를 링크의 state에 같이 넣어서 페이지 이동 시킴.
- 티켓의 날짜를 선택할 수 있는 기능 추가
경기 날짜에 대한 정보를 제공해주는 것이 아니어서, 등록의 범위를 야구 시즌으로 한정하여 좁혀봄.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

multi step 단계는 만들지 않고, 일단 step에 들어가는 내용 중 첫번째 단계만 완성한 상태.
