### PR TITLE
Refactor: 팀 리스트 변수 객체 형식으로 관리하도록 변경

### DIFF
--- a/src/components/MyTeamList/index.tsx
+++ b/src/components/MyTeamList/index.tsx
@@ -21,9 +21,9 @@ export default function MyTeamList() {
     <div>
       <ul css={styles.teamList}>
         {myTeams.map(myTeam => (
-          <li key={myTeam.team} css={styles.team}>
+          <li key={myTeam[0]} css={styles.team}>
             <button>
-              <img src={`/images/team/${myTeam.team}.png`} alt={myTeam.name} />
+              <img src={`/images/team/${myTeam[0]}.png`} alt={myTeam[1]} />
             </button>
           </li>
         ))}

--- a/src/components/PickTeamList/index.tsx
+++ b/src/components/PickTeamList/index.tsx
@@ -1,8 +1,8 @@
-import { TeamList } from '@typings/db';
+import { Teams } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
-  teams: TeamList;
+  teams: Teams;
 }
 
 export default function PickTeamList({ teams }: Props) {
@@ -13,11 +13,11 @@ export default function PickTeamList({ teams }: Props) {
   return (
     <ul css={styles.teamList}>
       {teams.map((team, index) => (
-        <li key={team.team}>
+        <li key={team[0]}>
           <button>
             <em>{index + 1}</em>
-            <img src={`/images/team/${team.team}.png`} alt={team.name} />
-            <span>{team.name}</span>
+            <img src={`/images/team/${team[0]}.png`} alt={team[1]} />
+            <span>{team[1]}</span>
           </button>
         </li>
       ))}

--- a/src/components/StadiumList/index.tsx
+++ b/src/components/StadiumList/index.tsx
@@ -1,11 +1,10 @@
 import { Link } from 'react-router-dom';
-import { TEAM_LIST } from '@constants/global';
+import { KBO_LEAGUE_STADIUMS, KBOTeams } from '@constants/global';
 import { useModalStore } from '@store/useModalStore';
-import { Team } from '@typings/db';
 import { styles } from './styles';
 
-function getAwayTeams(team: Team) {
-  return TEAM_LIST.filter(teamInfo => teamInfo.team !== team);
+function getAwayTeams(teamId: string) {
+  return KBOTeams.filter(team => team[0] !== teamId);
 }
 
 export default function StadiumList() {
@@ -13,20 +12,21 @@ export default function StadiumList() {
 
   return (
     <ul css={styles.stadiumSelect}>
-      {TEAM_LIST.map(team => (
-        <li key={team.team}>
+      {KBOTeams.map(team => (
+        <li key={team[0]}>
           <span
             style={{
-              '--team-logo': `url('/images/team/${team.team}.png')`,
+              '--team-logo': `url('/images/team/${team[0]}.png')`,
             }}
           >
-            <em>{team.name}</em>
-            <em>{team.stadium}</em>
+            <em>{team[1]}</em>
+            <em>{KBO_LEAGUE_STADIUMS[team[0]]}</em>
             <Link
               to="/register"
               state={{
-                homeTeam: { ...team },
-                awayTeams: getAwayTeams(team.team),
+                homeTeam: [...team],
+                awayTeams: getAwayTeams(team[0]),
+                stadium: KBO_LEAGUE_STADIUMS[team[0]],
               }}
               onClick={closeModal}
             >

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -4,7 +4,7 @@ import PickTeamList from '@components/PickTeamList';
 import TeamPickerList from '@components/TeamPickerList';
 import { useModalStore, useTeamStore } from '@store/.';
 import { colors } from '@styles/theme';
-import { Team, TeamName } from '@typings/db';
+import { TeamId, TeamName } from '@typings/db';
 import { styles } from './styles';
 
 export default function TeamPicker() {
@@ -15,14 +15,18 @@ export default function TeamPicker() {
 
   function onChangeTeam(
     e: React.ChangeEvent<
-      HTMLInputElement & { value: Team; dataset: { value: TeamName } }
+      HTMLInputElement & { value: TeamId; dataset: { value: TeamName } }
     >
   ) {
-    const team = { team: e.target.value, name: e.target.dataset.value };
     if (e.target.checked) {
-      setPickedTeams(prev => prev.concat(team));
+      setPickedTeams(prev => [
+        ...prev,
+        [e.target.value, e.target.dataset.value],
+      ]);
     } else {
-      setPickedTeams(prev => prev.filter(exTeam => exTeam.team !== team.team));
+      setPickedTeams(prev =>
+        prev.filter(exTeam => exTeam[0] != e.target.value)
+      );
     }
   }
 

--- a/src/components/TeamPickerList/index.tsx
+++ b/src/components/TeamPickerList/index.tsx
@@ -1,33 +1,31 @@
 import Checkbox from '@components/common/Checkbox';
-import { TEAM_LIST } from '@constants/global';
-import { Team, TeamList } from '@typings/db';
+import { KBOTeams } from '@constants/global';
+import { TeamId, Teams } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
-  teams: TeamList;
+  teams: Teams;
   onChangeTeam: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-export default function TeamPickerList({ teams, onChangeTeam }: Props) {
-  function getTeamIsChecked(team: Team) {
-    return teams.findIndex(teamInfo => teamInfo.team == team) !== -1;
-  }
+function getTeamIsChecked(teams: Teams, teamId: TeamId) {
+  return teams.findIndex(team => team[0] == teamId) !== -1;
+}
 
+export default function TeamPickerList({ teams, onChangeTeam }: Props) {
   return (
     <ul css={styles.teamList}>
-      {TEAM_LIST.map(team => (
-        <li key={team.team}>
-          <span
-            style={{ '--team-logo': `url('/images/team/${team.team}.png')` }}
-          >
+      {KBOTeams.map(team => (
+        <li key={team[0]}>
+          <span style={{ '--team-logo': `url('/images/team/${team[0]}.png')` }}>
             <Checkbox
-              id={team.team}
+              id={team[0]}
               name="team"
-              value={team.team}
-              checked={getTeamIsChecked(team.team)}
+              value={team[0]}
+              checked={getTeamIsChecked(teams, team[0])}
               onChange={onChangeTeam}
-              label={team.name}
-              data-value={team.name}
+              label={team[1]}
+              data-value={team[1]}
             />
           </span>
         </li>

--- a/src/constants/global.ts
+++ b/src/constants/global.ts
@@ -1,14 +1,31 @@
-export const TEAM_LIST = [
-  { team: 'KT', name: 'KT', stadium: '수원 KT 위즈 파크' },
-  { team: 'OB', name: '두산', stadium: '서울 잠실야구장(두산)' },
-  { team: 'SS', name: '삼성', stadium: '대구 삼성 라이온즈 파크' },
-  { team: 'LG', name: 'LG', stadium: '서울 잠실야구장(LG)' },
-  { team: 'WO', name: '키움', stadium: '고척 스카이돔' },
-  { team: 'SK', name: 'SSG', stadium: '인천 SSG 랜더스필드' },
-  { team: 'LT', name: '롯데', stadium: '부산 사직야구장' },
-  { team: 'NC', name: 'NC', stadium: '창원 NC 파크' },
-  { team: 'HT', name: '기아', stadium: '광주 기아 챔피언스 필드' },
-  { team: 'HH', name: '한화', stadium: '대전 한화생명 이글스파크' },
-] as const;
+import { Teams } from '@typings/db';
 
 export const BASE_URL = 'http://localhost:8080/api';
+
+export const KBO_LEAGUE_TEAMS = {
+  KT: 'KT',
+  OB: '두산',
+  SS: '삼성',
+  LG: 'LG',
+  WO: '키움',
+  SK: 'SSG',
+  LT: '롯데',
+  NC: 'NC',
+  HT: 'KIA',
+  HH: '한화',
+} as const;
+
+export const KBOTeams = Object.entries(KBO_LEAGUE_TEAMS) as Teams;
+
+export const KBO_LEAGUE_STADIUMS = {
+  KT: '수원 KT 위즈 파크',
+  OB: '서울 잠실야구장(두산)',
+  SS: '대구 삼성 라이온즈 파크',
+  LG: '서울 잠실야구장(LG)',
+  WO: '고척 스카이돔',
+  SK: '인천 SSG 랜더스필드',
+  LT: '부산 사직야구장',
+  NC: '창원 NC 파크',
+  HT: '광주 기아 챔피언스 필드',
+  HH: '대전 한화생명 이글스파크',
+} as const;

--- a/src/services/teams.ts
+++ b/src/services/teams.ts
@@ -1,11 +1,16 @@
-import { TeamList } from '@typings/db';
+import { TeamId } from '@typings/db';
 import { httpClient } from '.';
 
+type FetchMyTeams = Array<{
+  id: number;
+  team: TeamId;
+}>;
+
 export async function fetchMyTeams() {
-  const response = await httpClient.get<TeamList>('/teams');
+  const response = await httpClient.get<FetchMyTeams>('/teams');
   return response.data;
 }
 
-export function updateMyTeams(teams: TeamList) {
-  return httpClient.post('/teams/update', { teams });
+export function updateMyTeams(teamIds: TeamId[]) {
+  return httpClient.post('/teams/update', { teams: teamIds });
 }

--- a/src/store/useTeamStore.ts
+++ b/src/store/useTeamStore.ts
@@ -1,11 +1,12 @@
 import create from 'zustand';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
 import { fetchMyTeams, updateMyTeams } from '@services/teams';
-import { TeamList } from '@typings/db';
+import { Teams } from '@typings/db';
 import { useModalStore } from './useModalStore';
 
 interface TeamState {
-  myTeams: TeamList;
-  changeMyTeams(teams: TeamList): Promise<void>;
+  myTeams: Teams;
+  changeMyTeams(teams: Teams): Promise<void>;
   getMyTeams(): Promise<void>;
 }
 
@@ -13,7 +14,8 @@ export const useTeamStore = create<TeamState>()(set => ({
   myTeams: [],
   changeMyTeams: async teams => {
     try {
-      await updateMyTeams(teams);
+      const teamIds = teams.map(team => team[0]);
+      await updateMyTeams(teamIds);
       set({ myTeams: teams });
       useModalStore.setState({ modal: '' });
     } catch (error) {
@@ -22,8 +24,13 @@ export const useTeamStore = create<TeamState>()(set => ({
   },
   getMyTeams: async () => {
     try {
-      const teams = await fetchMyTeams();
-      set({ myTeams: teams });
+      const myTeams = await fetchMyTeams();
+      set({
+        myTeams: myTeams.map(myTeam => [
+          myTeam.team,
+          KBO_LEAGUE_TEAMS[myTeam.team],
+        ]),
+      });
     } catch (error) {
       console.error(error);
     }

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -1,4 +1,4 @@
-import { TEAM_LIST } from '@constants/global';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
 
 export interface User {
   id: number;
@@ -7,9 +7,6 @@ export interface User {
   provider: string | null;
 }
 
-export type Team = typeof TEAM_LIST[number]['team'];
-export type TeamName = typeof TEAM_LIST[number]['name'];
-export type TeamList = Array<{
-  team: Team;
-  name: TeamName;
-}>;
+export type TeamId = keyof typeof KBO_LEAGUE_TEAMS;
+export type TeamName = typeof KBO_LEAGUE_TEAMS[TeamId];
+export type Teams = Array<[TeamId, TeamName]>;


### PR DESCRIPTION
## What is this PR?

팀 리스트 변수 저장 방식 변경

## Changes

- 기존에 배열 안에 팀 id, name, stadium 등의 정보를 모두 넣어 관리하게 되면
특정 팀의 name, stadium 값만 찾기가 어려워,
팀의 `Id`를 키 값으로 하여, 각 팀의 name, stadium 값을 객체를 생성하여 별도로 저장함.

- 팀 리스트를 렌더링하는 경우, id, name은 같이 쓰이는 경우가 많아,
배열 형태로 가공하여 같이 사용할 수 있게 함.

- `teams` 같은 변수명은 사용할 때 중복되는 경우가 많아
특정 리그를 표현하는 명칭을 접두사로 붙이도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] 기존에 작성해놓은 코드 정상적으로 돌아가는지 확인.

## Etc

없음
