### PR TITLE
Feat: 티켓 등록 폼 시즌 선택 단계 추가

### DIFF
--- a/src/components/SetMatchSeason/index.tsx
+++ b/src/components/SetMatchSeason/index.tsx
@@ -1,8 +1,15 @@
+import RadioButton from '@components/common/RadioButton';
 import SetMatchSeries from '@components/SetMatchSeries';
 import {
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
+import { styles } from './styles';
+
+interface RadioButtonGroupProps {
+  checkedValue: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}
 
 const KBO_LEAGUE_SEASONS = ['정규시즌', '포스트시즌'];
 
@@ -15,24 +22,31 @@ export default function SetMatchSeason() {
   }
 
   return (
-    <div>
+    <div css={styles.wrapper}>
       <h3>경기 시즌을 선택하세요</h3>
-      <div>
-        {KBO_LEAGUE_SEASONS.map(season => (
-          <span key={season}>
-            <input
-              type="radio"
-              name="season"
-              id={season}
-              value={season}
-              checked={matchSeason == season}
-              onChange={onChangeMatchSeason}
-            />
-            <label htmlFor={season}>{season}</label>
-          </span>
-        ))}
-      </div>
+      <RadioButtonGroup
+        checkedValue={matchSeason}
+        onChange={onChangeMatchSeason}
+      />
       {matchSeason == '포스트시즌' && <SetMatchSeries />}
+    </div>
+  );
+}
+
+function RadioButtonGroup({ checkedValue, onChange }: RadioButtonGroupProps) {
+  return (
+    <div css={styles.radioButtonWrapper}>
+      {KBO_LEAGUE_SEASONS.map(season => (
+        <RadioButton
+          key={season}
+          id={season}
+          value={season}
+          name="season"
+          checked={checkedValue == season}
+          onChange={onChange}
+          label={season}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/SetMatchSeason/index.tsx
+++ b/src/components/SetMatchSeason/index.tsx
@@ -1,0 +1,38 @@
+import SetMatchSeries from '@components/SetMatchSeries';
+import {
+  useTicketForm,
+  useTicketFormDispatch,
+} from '@context/TicketFormContext';
+
+const KBO_LEAGUE_SEASONS = ['정규시즌', '포스트시즌'];
+
+export default function SetMatchSeason() {
+  const { matchSeason } = useTicketForm();
+  const ticketFormDispatch = useTicketFormDispatch();
+
+  function onChangeMatchSeason(e: React.ChangeEvent<HTMLInputElement>) {
+    ticketFormDispatch({ type: 'SET_MATCH_SEASON', season: e.target.value });
+  }
+
+  return (
+    <div>
+      <h3>경기 시즌을 선택하세요</h3>
+      <div>
+        {KBO_LEAGUE_SEASONS.map(season => (
+          <span key={season}>
+            <input
+              type="radio"
+              name="season"
+              id={season}
+              value={season}
+              checked={matchSeason == season}
+              onChange={onChangeMatchSeason}
+            />
+            <label htmlFor={season}>{season}</label>
+          </span>
+        ))}
+      </div>
+      {matchSeason == '포스트시즌' && <SetMatchSeries />}
+    </div>
+  );
+}

--- a/src/components/SetMatchSeason/styles.ts
+++ b/src/components/SetMatchSeason/styles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+  wrapper: css({
+    h3: {
+      padding: '1rem 0',
+    },
+  }),
+  radioButtonWrapper: css({
+    display: 'flex',
+    marginLeft: '-1rem',
+    '> div': {
+      flex: '0 1 50%',
+      margin: '0 0 1rem 1rem',
+    },
+  }),
+};

--- a/src/components/SetMatchSeries/index.tsx
+++ b/src/components/SetMatchSeries/index.tsx
@@ -1,7 +1,14 @@
+import RadioButton from '@components/common/RadioButton';
 import {
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
+import { styles } from './styles';
+
+interface RadioButtonGroupProps {
+  checkedValue: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}
 
 const KBO_POSTSEASON_SERIES = [
   '와일드카드 결정전',
@@ -21,21 +28,28 @@ export default function SetMatchSeries() {
   return (
     <div>
       <h3>시리즈를 선택하세요</h3>
-      <div>
-        {KBO_POSTSEASON_SERIES.map(series => (
-          <span key={series}>
-            <input
-              type="radio"
-              name="series"
-              id={series}
-              value={series}
-              checked={matchSeries == series}
-              onChange={onChangeMatchSeries}
-            />
-            <label htmlFor={series}>{series}</label>
-          </span>
-        ))}
-      </div>
+      <RadioButtonGroup
+        checkedValue={matchSeries}
+        onChange={onChangeMatchSeries}
+      />
+    </div>
+  );
+}
+
+function RadioButtonGroup({ checkedValue, onChange }: RadioButtonGroupProps) {
+  return (
+    <div css={styles.radioButtonWrapper}>
+      {KBO_POSTSEASON_SERIES.map(series => (
+        <RadioButton
+          key={series}
+          id={series}
+          value={series}
+          name="series"
+          checked={checkedValue == series}
+          onChange={onChange}
+          label={series}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/SetMatchSeries/index.tsx
+++ b/src/components/SetMatchSeries/index.tsx
@@ -1,0 +1,41 @@
+import {
+  useTicketForm,
+  useTicketFormDispatch,
+} from '@context/TicketFormContext';
+
+const KBO_POSTSEASON_SERIES = [
+  '와일드카드 결정전',
+  '준플레이오프',
+  '플레이오프',
+  '한국시리즈',
+];
+
+export default function SetMatchSeries() {
+  const { matchSeries } = useTicketForm();
+  const ticketFormDispatch = useTicketFormDispatch();
+
+  function onChangeMatchSeries(e: React.ChangeEvent<HTMLInputElement>) {
+    ticketFormDispatch({ type: 'SET_MATCH_SERIES', series: e.target.value });
+  }
+
+  return (
+    <div>
+      <h3>시리즈를 선택하세요</h3>
+      <div>
+        {KBO_POSTSEASON_SERIES.map(series => (
+          <span key={series}>
+            <input
+              type="radio"
+              name="series"
+              id={series}
+              value={series}
+              checked={matchSeries == series}
+              onChange={onChangeMatchSeries}
+            />
+            <label htmlFor={series}>{series}</label>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SetMatchSeries/styles.ts
+++ b/src/components/SetMatchSeries/styles.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  radioButtonWrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    '> div': {
+      margin: '0 0 1rem 0',
+    },
+    [mq('xs')]: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      marginLeft: '-1rem',
+      '> div': {
+        maxWidth: 'calc(50% - 1rem)',
+        flexBasis: '50%',
+        margin: '0 0 1rem 1rem',
+      },
+    },
+    [mq('md')]: {
+      '> div': {
+        maxWidth: 'calc(25% - 1rem)',
+        flexBasis: '25%',
+      },
+    },
+  }),
+};

--- a/src/components/common/RadioButton/index.tsx
+++ b/src/components/common/RadioButton/index.tsx
@@ -1,0 +1,17 @@
+import { styles } from './styles';
+
+interface RadioButtonProps {
+  label?: React.ReactNode;
+}
+
+export default function RadioButton({
+  label,
+  ...props
+}: React.ComponentPropsWithRef<'input'> & RadioButtonProps) {
+  return (
+    <div key={props.key} css={styles.radioButton}>
+      <input type="radio" {...props} />
+      <label htmlFor={props.id}>{label}</label>
+    </div>
+  );
+}

--- a/src/components/common/RadioButton/styles.ts
+++ b/src/components/common/RadioButton/styles.ts
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  radioButton: css({
+    display: 'flex',
+    input: {
+      appearance: 'none',
+      margin: 0,
+      cursor: 'pointer',
+      '&:checked': {
+        '+ label': {
+          borderColor: colors.indigo[300],
+          background: colors.indigo[300],
+          color: colors.white,
+          fontWeight: 600,
+        },
+      },
+      '&:disabled': {
+        '+ label': {
+          cursor: 'not-allowed',
+          opacity: '.5',
+        },
+      },
+    },
+    label: {
+      flex: '1 1 auto',
+      padding: '1rem',
+      border: `1px solid ${colors.gray[200]}`,
+      borderRadius: 8,
+      background: colors.white,
+      boxShadow: '7px 7px 15px rgba(0,0,0,0.05)',
+      textAlign: 'center',
+      cursor: 'pointer',
+      transition: '.5s',
+    },
+  }),
+};

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -6,12 +6,16 @@ interface TicketFormContext {
     month: number;
     date: number;
   };
+  matchSeason: string;
+  matchSeries: string;
 }
 
 type TicketFormActions =
   | { type: 'SET_MATCH_YEAR'; year: number }
   | { type: 'SET_MATCH_MONTH'; month: number; date: number }
-  | { type: 'SET_MATCH_DATE'; date: number };
+  | { type: 'SET_MATCH_DATE'; date: number }
+  | { type: 'SET_MATCH_SEASON'; season: string }
+  | { type: 'SET_MATCH_SERIES'; series: string };
 
 const TicketFormContext = createContext<TicketFormContext | undefined>(
   undefined
@@ -44,6 +48,16 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
         ...state,
         matchDate: { ...state.matchDate, date: action.date },
       };
+    case 'SET_MATCH_SEASON':
+      return {
+        ...state,
+        matchSeason: action.season,
+      };
+    case 'SET_MATCH_SERIES':
+      return {
+        ...state,
+        matchSeries: action.series,
+      };
   }
 };
 
@@ -52,6 +66,8 @@ export function TicketFormProvider({
 }: React.PropsWithChildren<unknown>) {
   const [state, dispatch] = useReducer(ticketFormReducer, {
     matchDate: { year: 0, month: 0, date: 0 },
+    matchSeason: '',
+    matchSeries: '',
   });
 
   return (

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -52,6 +52,7 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
       return {
         ...state,
         matchSeason: action.season,
+        matchSeries: '',
       };
     case 'SET_MATCH_SERIES':
       return {

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Button from '@components/common/Button';
 import SetMatchDate from '@components/SetMatchDate';
+import SetMatchSeason from '@components/SetMatchSeason';
 import { useTicketForm } from '@context/TicketFormContext';
 import { colors } from '@styles/theme';
 import { styles } from './styles';
@@ -8,6 +9,8 @@ import { styles } from './styles';
 function renderTicketRegisterForm(step: number) {
   switch (step) {
     case 1:
+      return <SetMatchSeason />;
+    case 2:
       return <SetMatchDate />;
   }
 }
@@ -26,6 +29,15 @@ export default function TicketRegister() {
 
   function validateForm() {
     if (formStep == 1) {
+      const { matchSeason, matchSeries } = ticketForm;
+      if (
+        matchSeason == '정규시즌' ||
+        (matchSeason == '포스트시즌' && matchSeries)
+      )
+        return true;
+      return false;
+    }
+    if (formStep == 2) {
       const { year, month, date } = ticketForm.matchDate;
       if (year && month && date) return true;
       return false;


### PR DESCRIPTION
## What is this PR?

close #55

## Changes

- 폼 입력 단계 순서 변경
기존에 먼저 만들어둔 날짜 선택을 2단계로 옮기고, 시즌 선택을 첫번째 단계로 선택함.

- 공통 컴포넌트 `RadioButton` 추가
`RadioButton` 을 그룹화한 컴포넌트를 공통으로 만들려고 했지만,
표시하려는 레이아웃이 달라지면, 래퍼의 스타일 코드를 일일이 변경해야 해서 공통으로 빼는 것은 쉽지 않음.
라디오 버튼을 가져다 사용하는 컴포넌트에서 래핑 스타일을 만들어 그룹 컴포넌트를 만드는 방향으로 코드를 작성함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/194094303-d0a75f7f-02c1-4612-8f0f-33085930bdae.png" width="50%" /> |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194094469-11425914-3d70-4c20-b6c8-da01cf8c8f2a.png" width="50%" /> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194094309-2050638c-bd66-4d33-b8b6-753a1b6e397c.png" width="50%" /> |

## Test Checklist

- [x] 단계 이동에 필요한 정보가 모두 저장됐을 때만, 다음 단계 이동 버튼 활성화 확인

## Etc

없음
