### PR TITLE
Feat: 티켓 등록 폼 원정팀 선택 단계 추가

### DIFF
--- a/src/components/SetAwayTeam/index.tsx
+++ b/src/components/SetAwayTeam/index.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import RadioButton from '@components/common/RadioButton';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import {
+  type TicketFormLocationState,
+  useTicketForm,
+  useTicketFormDispatch,
+} from '@context/TicketFormContext';
+import { TeamId, Teams } from '@typings/db';
+import { styles } from './styles';
+
+interface AwayTeamListProps {
+  list: Teams;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  checkedValue?: string;
+}
+
+export default function SetAwayTeam() {
+  const location = useLocation();
+  const ticketFormState = location.state as TicketFormLocationState;
+
+  const ticketFormDispatch = useTicketFormDispatch();
+  const { homeTeam, awayTeam } = useTicketForm();
+  const [awayTeams, setAwayTeams] = useState(() => {
+    if (awayTeam)
+      return ticketFormState.awayTeams.filter(team => team[0] != awayTeam);
+    return ticketFormState.awayTeams;
+  });
+
+  function onChangeAwayTeam(
+    e: React.ChangeEvent<HTMLInputElement & { value: TeamId }>
+  ) {
+    const changedAwayTeams = ticketFormState.awayTeams.filter(
+      awayTeam => awayTeam[0] != e.target.value
+    );
+    setAwayTeams(changedAwayTeams);
+    ticketFormDispatch({
+      type: 'SET_AWAY_TEAM',
+      awayTeam: e.target.value,
+    });
+  }
+
+  return (
+    <div css={styles.wrapper}>
+      <h3>원정팀을 선택하세요</h3>
+      <div css={styles.matchup}>
+        <div>
+          {awayTeam ? (
+            <>
+              <img
+                src={`/images/team/${awayTeam}.png`}
+                alt={awayTeam && KBO_LEAGUE_TEAMS[awayTeam]}
+              />
+              <em>{awayTeam && KBO_LEAGUE_TEAMS[awayTeam]}</em>
+            </>
+          ) : (
+            <span>없음</span>
+          )}
+        </div>
+        <div>
+          <img
+            src={`/images/team/${homeTeam}.png`}
+            alt={homeTeam && KBO_LEAGUE_TEAMS[homeTeam]}
+          />
+          <em>{homeTeam && KBO_LEAGUE_TEAMS[homeTeam]}</em>
+          <small>*홈팀</small>
+        </div>
+      </div>
+      <AwayTeamList
+        list={awayTeams}
+        checkedValue={awayTeam}
+        onChange={onChangeAwayTeam}
+      />
+    </div>
+  );
+}
+
+function AwayTeamList({ list, onChange, checkedValue }: AwayTeamListProps) {
+  return (
+    <div css={styles.awayTeamList}>
+      {list.map(team => (
+        <RadioButton
+          key={team[0]}
+          id={team[0]}
+          value={team[0]}
+          checked={checkedValue == team[0]}
+          onChange={onChange}
+          label={team[1]}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/SetAwayTeam/styles.ts
+++ b/src/components/SetAwayTeam/styles.ts
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  wrapper: css({
+    h3: {
+      padding: '1rem 0',
+    },
+  }),
+  matchup: css({
+    display: 'flex',
+    marginLeft: '-1rem',
+    '> div': {
+      position: 'relative',
+      height: 150,
+      flex: '0 1 50%',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'space-around',
+      background: colors.gray[50],
+      borderRadius: 8,
+      padding: '1rem',
+      margin: '0 0 1rem 1rem',
+      em: {
+        fontWeight: 600,
+        fontSize: '1.4rem',
+      },
+      small: {
+        position: 'absolute',
+        top: '0.5rem',
+        right: '0.5rem',
+        fontSize: '0.875rem',
+        fontWeight: 600,
+        [mq('xs')]: {
+          top: '1rem',
+          right: '1rem',
+        },
+      },
+    },
+  }),
+  awayTeamList: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    marginLeft: '-0.5rem',
+    '> div': {
+      flex: '0 1 33.3%',
+      margin: '0 0 0.5rem 0.5rem',
+      maxWidth: 'calc(33.3% - 0.5rem)',
+    },
+    [mq('md')]: {
+      flexWrap: 'nowrap',
+    },
+  }),
+};

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -1,4 +1,12 @@
 import { createContext, useContext, useReducer } from 'react';
+import { useLocation } from 'react-router-dom';
+import { TeamId, Teams } from '@typings/db';
+
+export interface TicketFormLocationState {
+  homeTeam: Teams[number];
+  awayTeams: Teams;
+  stadium: string;
+}
 
 interface TicketFormContext {
   matchDate: {
@@ -8,6 +16,9 @@ interface TicketFormContext {
   };
   matchSeason: string;
   matchSeries: string;
+  homeTeam: TeamId | undefined;
+  awayTeam: TeamId | undefined;
+  stadium: string;
 }
 
 type TicketFormActions =
@@ -15,7 +26,11 @@ type TicketFormActions =
   | { type: 'SET_MATCH_MONTH'; month: number; date: number }
   | { type: 'SET_MATCH_DATE'; date: number }
   | { type: 'SET_MATCH_SEASON'; season: string }
-  | { type: 'SET_MATCH_SERIES'; series: string };
+  | { type: 'SET_MATCH_SERIES'; series: string }
+  | {
+      type: 'SET_AWAY_TEAM';
+      awayTeam: TeamId;
+    };
 
 const TicketFormContext = createContext<TicketFormContext | undefined>(
   undefined
@@ -59,16 +74,27 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
         ...state,
         matchSeries: action.series,
       };
+    case 'SET_AWAY_TEAM':
+      return {
+        ...state,
+        awayTeam: action.awayTeam,
+      };
   }
 };
 
 export function TicketFormProvider({
   children,
 }: React.PropsWithChildren<unknown>) {
+  const location = useLocation();
+  const ticketFormState = location.state as TicketFormLocationState;
+
   const [state, dispatch] = useReducer(ticketFormReducer, {
     matchDate: { year: 0, month: 0, date: 0 },
     matchSeason: '',
     matchSeries: '',
+    homeTeam: ticketFormState.homeTeam[0],
+    awayTeam: undefined,
+    stadium: ticketFormState.stadium,
   });
 
   return (

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -45,6 +45,11 @@ export default function TicketRegister() {
       if (year && month && date) return true;
       return false;
     }
+    if (formStep == 3) {
+      const { homeTeam, awayTeam, stadium } = ticketForm;
+      if (homeTeam && awayTeam && stadium) return true;
+      return false;
+    }
   }
 
   return (

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@components/common/Button';
+import SetAwayTeam from '@components/SetAwayTeam';
 import SetMatchDate from '@components/SetMatchDate';
 import SetMatchSeason from '@components/SetMatchSeason';
 import { useTicketForm } from '@context/TicketFormContext';
@@ -12,6 +13,8 @@ function renderTicketRegisterForm(step: number) {
       return <SetMatchSeason />;
     case 2:
       return <SetMatchDate />;
+    case 3:
+      return <SetAwayTeam />;
   }
 }
 


### PR DESCRIPTION
## What is this PR?

close #57

## Changes

- 티켓 등록 페이지로 이동할 때, 전달됐던 `location.state` 값에서 홈팀, 원정팀 리스트, 구장 정보를 가져다 사용함.
state의 타입이 unknown으로 타이핑되어 있어서 전달한 값을 사용하려면, `as`로 타이핑 단언 할 수 밖에 없었음.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/194341629-997471c3-c5dd-4ce2-9ad3-d81de2080158.png" width="50%"> |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194341623-9b45ab26-bdd7-4373-b2d5-291e839b12ad.png" width="50%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194341635-59194738-c0f3-4000-8cfd-f6908502d883.png" width="50%"> |

## Test Checklist

- [x] 선택된 원정팀은 변경 가능한 원정 리스트에서 제외.
- [x] 폼 유효성 검사를 통과할 때만, 다음 단계 버튼 활성화  

## Etc

없음
