### PR TITLE
Feat: 티켓 등록 폼 - 응원팀 선택 단계 추가

### DIFF
--- a/src/components/SetMyTeam/index.tsx
+++ b/src/components/SetMyTeam/index.tsx
@@ -1,0 +1,48 @@
+import RadioButton from '@components/common/RadioButton';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import {
+  useTicketForm,
+  useTicketFormDispatch,
+} from '@context/TicketFormContext';
+import { TeamId } from '@typings/db';
+import { styles } from './styles';
+
+export default function SetMyTeam() {
+  const { homeTeam, awayTeam, myTeam } = useTicketForm();
+  const ticketFormDispatch = useTicketFormDispatch();
+
+  function onChangeMyTeam(
+    e: React.ChangeEvent<HTMLInputElement & { value: TeamId }>
+  ) {
+    ticketFormDispatch({ type: 'SET_MYTEAM', team: e.target.value });
+  }
+
+  return (
+    <div css={styles.wrapper}>
+      <h3>응원팀을 선택하세요</h3>
+      <div css={styles.matchTeams}>
+        {[awayTeam, homeTeam].map(team => (
+          <RadioButton
+            key={team}
+            id={team}
+            value={team}
+            checked={team == myTeam}
+            onChange={onChangeMyTeam}
+            label={
+              team && (
+                <div css={styles.team}>
+                  <img
+                    src={`/images/team/${team}.png`}
+                    alt={KBO_LEAGUE_TEAMS[team]}
+                  />
+                  <em>{KBO_LEAGUE_TEAMS[team]}</em>
+                  {team == homeTeam && <small>*홈팀</small>}
+                </div>
+              )
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SetMyTeam/styles.ts
+++ b/src/components/SetMyTeam/styles.ts
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+
+export const styles = {
+  wrapper: css({
+    h3: {
+      padding: '1rem 0',
+    },
+  }),
+  matchTeams: css({
+    display: 'flex',
+    marginLeft: '-1rem',
+    '> *': {
+      flex: '0 1 50%',
+      margin: '0 0 1rem 1rem',
+      position: 'relative',
+    },
+  }),
+  team: css({
+    height: 114,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    em: {
+      fontWeight: 600,
+      fontSize: '1.4rem',
+    },
+    small: {
+      position: 'absolute',
+      top: '0.5rem',
+      right: '0.5rem',
+      fontSize: '0.875rem',
+      fontWeight: 600,
+      [mq('xs')]: {
+        top: '1rem',
+        right: '1rem',
+      },
+    },
+  }),
+};

--- a/src/components/common/RadioButton/styles.ts
+++ b/src/components/common/RadioButton/styles.ts
@@ -10,9 +10,8 @@ export const styles = {
       cursor: 'pointer',
       '&:checked': {
         '+ label': {
-          borderColor: colors.indigo[300],
-          background: colors.indigo[300],
-          color: colors.white,
+          border: `2px solid ${colors.indigo[300]}`,
+          background: colors.indigo[50],
           fontWeight: 600,
         },
       },
@@ -32,7 +31,7 @@ export const styles = {
       boxShadow: '7px 7px 15px rgba(0,0,0,0.05)',
       textAlign: 'center',
       cursor: 'pointer',
-      transition: '.5s',
+      transition: 'background .5s',
     },
   }),
 };

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -19,6 +19,8 @@ interface TicketFormContext {
   homeTeam: TeamId | undefined;
   awayTeam: TeamId | undefined;
   stadium: string;
+  myTeam: TeamId | undefined;
+  opponentTeam: TeamId | undefined;
 }
 
 type TicketFormActions =
@@ -30,7 +32,8 @@ type TicketFormActions =
   | {
       type: 'SET_AWAY_TEAM';
       awayTeam: TeamId;
-    };
+    }
+  | { type: 'SET_MYTEAM'; team: TeamId };
 
 const TicketFormContext = createContext<TicketFormContext | undefined>(
   undefined
@@ -79,6 +82,13 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
         ...state,
         awayTeam: action.awayTeam,
       };
+    case 'SET_MYTEAM':
+      return {
+        ...state,
+        myTeam: action.team,
+        opponentTeam:
+          action.team == state.homeTeam ? state.awayTeam : state.homeTeam,
+      };
   }
 };
 
@@ -95,6 +105,8 @@ export function TicketFormProvider({
     homeTeam: ticketFormState.homeTeam[0],
     awayTeam: undefined,
     stadium: ticketFormState.stadium,
+    myTeam: undefined,
+    opponentTeam: undefined,
   });
 
   return (

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -81,6 +81,8 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
       return {
         ...state,
         awayTeam: action.awayTeam,
+        myTeam: undefined,
+        opponentTeam: undefined,
       };
     case 'SET_MYTEAM':
       return {

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -3,6 +3,7 @@ import Button from '@components/common/Button';
 import SetAwayTeam from '@components/SetAwayTeam';
 import SetMatchDate from '@components/SetMatchDate';
 import SetMatchSeason from '@components/SetMatchSeason';
+import SetMyTeam from '@components/SetMyTeam';
 import { useTicketForm } from '@context/TicketFormContext';
 import { colors } from '@styles/theme';
 import { styles } from './styles';
@@ -15,6 +16,8 @@ function renderTicketRegisterForm(step: number) {
       return <SetMatchDate />;
     case 3:
       return <SetAwayTeam />;
+    case 4:
+      return <SetMyTeam />;
   }
 }
 

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -53,6 +53,11 @@ export default function TicketRegister() {
       if (homeTeam && awayTeam && stadium) return true;
       return false;
     }
+    if (formStep == 4) {
+      const { myTeam, opponentTeam } = ticketForm;
+      if (myTeam && opponentTeam) return true;
+      return false;
+    }
   }
 
   return (


### PR DESCRIPTION
## What is this PR?

close #59 

## Changes

- 공통 컴포넌트 RadioButton, `background`, `border` 속성값 수정
label 요소의 컨텐츠에 따라, 조금 더 일반적으로 사용할 수 있도록 무난한 스타일로 변경함.
- 이전 단계와 비슷한 UI이지만, 기능이 다른 것 같아 공통 요소로 빼지 않음.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/194363164-4e16462a-174a-4b9e-bf75-af689f717331.png" width="50%"> |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194363397-2e915f45-a730-48ea-9649-53a64cdd7195.png" width="50%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194363044-3f128b04-ff80-435b-9f2e-4b4e7dacef72.png" width="50%"> |

## Test Checklist

- [x] 폼 유효성 검사를 통과한 후에만, 다음 단계 버튼 활성화
- [x] 이전 단계로 돌아가, 원정팀을 변경한 경우 기존의 응원팀 선택 초기화 

## Etc

없음
