### PR TITLE
Feat: 티켓 등록 폼 스코어 입력 단계 추가

### DIFF
--- a/src/components/SetMatchScore/index.tsx
+++ b/src/components/SetMatchScore/index.tsx
@@ -1,0 +1,62 @@
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import {
+  useTicketForm,
+  useTicketFormDispatch,
+} from '@context/TicketFormContext';
+
+export default function SetMatchScore() {
+  const { homeTeam, awayTeam, score } = useTicketForm();
+  const ticketFormDispatch = useTicketFormDispatch();
+
+  function onChangeAwayTeamScore(e: React.ChangeEvent<HTMLInputElement>) {
+    const score = +e.target.value;
+    if (isNaN(score) || score > 99) return;
+    ticketFormDispatch({ type: 'SET_AWAYTEAM_SCORE', score });
+  }
+
+  function onChangeHomeTeamScore(e: React.ChangeEvent<HTMLInputElement>) {
+    const score = +e.target.value;
+    if (isNaN(score) || score > 99) return;
+    ticketFormDispatch({ type: 'SET_HOMETEAM_SCORE', score });
+  }
+
+  if (!(homeTeam && awayTeam)) return null;
+
+  return (
+    <div>
+      <h3>경기 결과를 입력하세요</h3>
+      <div>
+        <div>
+          <input
+            type="text"
+            id="awayTeam"
+            value={score.awayTeam}
+            onChange={onChangeAwayTeamScore}
+          />
+          <label htmlFor="awayTeam">
+            <img
+              src={`/images/team/${awayTeam}.png`}
+              alt={KBO_LEAGUE_TEAMS[awayTeam]}
+            />
+            <span>{KBO_LEAGUE_TEAMS[awayTeam]}</span>
+          </label>
+        </div>
+        <div>
+          <input
+            type="text"
+            id="homeTeam"
+            value={score.homeTeam}
+            onChange={onChangeHomeTeamScore}
+          />
+          <label htmlFor="homeTeam">
+            <img
+              src={`/images/team/${homeTeam}.png`}
+              alt={KBO_LEAGUE_TEAMS[homeTeam]}
+            />
+            <span>{KBO_LEAGUE_TEAMS[homeTeam]}</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SetMatchScore/index.tsx
+++ b/src/components/SetMatchScore/index.tsx
@@ -3,6 +3,7 @@ import {
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
+import { styles } from './styles';
 
 export default function SetMatchScore() {
   const { homeTeam, awayTeam, score } = useTicketForm();
@@ -23,10 +24,10 @@ export default function SetMatchScore() {
   if (!(homeTeam && awayTeam)) return null;
 
   return (
-    <div>
+    <div css={styles.wrapper}>
       <h3>경기 결과를 입력하세요</h3>
-      <div>
-        <div>
+      <div css={styles.scordBoardWrapper}>
+        <div css={styles.scoreBoard}>
           <input
             type="text"
             id="awayTeam"
@@ -41,7 +42,7 @@ export default function SetMatchScore() {
             <span>{KBO_LEAGUE_TEAMS[awayTeam]}</span>
           </label>
         </div>
-        <div>
+        <div css={styles.scoreBoard}>
           <input
             type="text"
             id="homeTeam"

--- a/src/components/SetMatchScore/index.tsx
+++ b/src/components/SetMatchScore/index.tsx
@@ -3,7 +3,14 @@ import {
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
+import { TeamId } from '@typings/db';
 import { styles } from './styles';
+
+interface ScordBoardProp {
+  team: TeamId;
+  score: number;
+  onChangeTeamScore: React.ChangeEventHandler;
+}
 
 export default function SetMatchScore() {
   const { homeTeam, awayTeam, score } = useTicketForm();
@@ -26,38 +33,30 @@ export default function SetMatchScore() {
   return (
     <div css={styles.wrapper}>
       <h3>경기 결과를 입력하세요</h3>
-      <div css={styles.scordBoardWrapper}>
-        <div css={styles.scoreBoard}>
-          <input
-            type="text"
-            id="awayTeam"
-            value={score.awayTeam}
-            onChange={onChangeAwayTeamScore}
-          />
-          <label htmlFor="awayTeam">
-            <img
-              src={`/images/team/${awayTeam}.png`}
-              alt={KBO_LEAGUE_TEAMS[awayTeam]}
-            />
-            <span>{KBO_LEAGUE_TEAMS[awayTeam]}</span>
-          </label>
-        </div>
-        <div css={styles.scoreBoard}>
-          <input
-            type="text"
-            id="homeTeam"
-            value={score.homeTeam}
-            onChange={onChangeHomeTeamScore}
-          />
-          <label htmlFor="homeTeam">
-            <img
-              src={`/images/team/${homeTeam}.png`}
-              alt={KBO_LEAGUE_TEAMS[homeTeam]}
-            />
-            <span>{KBO_LEAGUE_TEAMS[homeTeam]}</span>
-          </label>
-        </div>
+      <div css={styles.scoreBoardWrapper}>
+        <ScoreBoard
+          team={awayTeam}
+          score={score.awayTeam}
+          onChangeTeamScore={onChangeAwayTeamScore}
+        />
+        <ScoreBoard
+          team={homeTeam}
+          score={score.homeTeam}
+          onChangeTeamScore={onChangeHomeTeamScore}
+        />
       </div>
+    </div>
+  );
+}
+
+function ScoreBoard({ team, score, onChangeTeamScore }: ScordBoardProp) {
+  return (
+    <div css={styles.scoreBoard}>
+      <input type="text" id={team} value={score} onChange={onChangeTeamScore} />
+      <label htmlFor={team}>
+        <img src={`/images/team/${team}.png`} alt={KBO_LEAGUE_TEAMS[team]} />
+        <span>{KBO_LEAGUE_TEAMS[team]}</span>
+      </label>
     </div>
   );
 }

--- a/src/components/SetMatchScore/styles.ts
+++ b/src/components/SetMatchScore/styles.ts
@@ -1,0 +1,70 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  wrapper: css({
+    h3: {
+      padding: '1rem 0',
+    },
+  }),
+  scoreBoardWrapper: css({
+    [mq('sm')]: {
+      display: 'flex',
+      marginLeft: '-1rem',
+    },
+  }),
+  scoreBoard: css({
+    display: 'flex',
+    marginBottom: '1rem',
+    label: {
+      order: 1,
+      flexBasis: '70%',
+      display: 'flex',
+      alignItems: 'center',
+      fontWeight: 600,
+      fontSize: '1.4rem',
+      background: colors.gray[50],
+      borderRadius: '8px 0 0 8px',
+      img: {
+        margin: '0 1rem 0 0.5rem',
+        width: 60,
+      },
+    },
+    input: {
+      height: 90,
+      order: 2,
+      flexBasis: '30%',
+      width: '100%',
+      padding: 0,
+      border: `1px solid ${colors.gray[100]}`,
+      borderWidth: '1px 1px 1px 0',
+      borderRadius: '0 8px 8px 0',
+      textAlign: 'center',
+      fontSize: '3rem',
+      fontWeight: 600,
+      outline: 'none',
+    },
+    [mq('sm')]: {
+      flex: '0 1 50%',
+      margin: '0 0 1rem 1rem',
+      flexDirection: 'column',
+      label: {
+        height: 60,
+        order: 2,
+        flexBasis: 'auto',
+        justifyContent: 'center',
+        borderRadius: '0 0 8px 8px',
+        img: {
+          margin: '0 1rem 0 0',
+        },
+      },
+      input: {
+        order: 1,
+        flexBasis: 'auto',
+        borderWidth: '1px 1px 0 1px',
+        borderRadius: '8px 8px 0 0',
+      },
+    },
+  }),
+};

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -25,6 +25,7 @@ interface TicketFormContext {
     homeTeam: number;
     awayTeam: number;
   };
+  scoreType: string;
 }
 
 type TicketFormActions =
@@ -40,6 +41,12 @@ type TicketFormActions =
   | { type: 'SET_MYTEAM'; team: TeamId }
   | { type: 'SET_HOMETEAM_SCORE'; score: number }
   | { type: 'SET_AWAYTEAM_SCORE'; score: number };
+
+function getScoreType(myScore: number, opponentScore: number) {
+  if (myScore > opponentScore) return '승';
+  if (myScore < opponentScore) return '패';
+  return '무';
+}
 
 const TicketFormContext = createContext<TicketFormContext | undefined>(
   undefined
@@ -101,11 +108,19 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
       return {
         ...state,
         score: { ...state.score, awayTeam: action.score },
+        scoreType:
+          state.awayTeam == state.myTeam
+            ? getScoreType(action.score, state.score.homeTeam)
+            : getScoreType(state.score.homeTeam, action.score),
       };
     case 'SET_HOMETEAM_SCORE':
       return {
         ...state,
         score: { ...state.score, homeTeam: action.score },
+        scoreType:
+          state.homeTeam == state.myTeam
+            ? getScoreType(action.score, state.score.awayTeam)
+            : getScoreType(state.score.homeTeam, action.score),
       };
   }
 };
@@ -129,6 +144,7 @@ export function TicketFormProvider({
       homeTeam: 0,
       awayTeam: 0,
     },
+    scoreType: '무',
   });
 
   return (

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -21,6 +21,10 @@ interface TicketFormContext {
   stadium: string;
   myTeam: TeamId | undefined;
   opponentTeam: TeamId | undefined;
+  score: {
+    homeTeam: number;
+    awayTeam: number;
+  };
 }
 
 type TicketFormActions =
@@ -33,7 +37,9 @@ type TicketFormActions =
       type: 'SET_AWAY_TEAM';
       awayTeam: TeamId;
     }
-  | { type: 'SET_MYTEAM'; team: TeamId };
+  | { type: 'SET_MYTEAM'; team: TeamId }
+  | { type: 'SET_HOMETEAM_SCORE'; score: number }
+  | { type: 'SET_AWAYTEAM_SCORE'; score: number };
 
 const TicketFormContext = createContext<TicketFormContext | undefined>(
   undefined
@@ -91,6 +97,16 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
         opponentTeam:
           action.team == state.homeTeam ? state.awayTeam : state.homeTeam,
       };
+    case 'SET_AWAYTEAM_SCORE':
+      return {
+        ...state,
+        score: { ...state.score, awayTeam: action.score },
+      };
+    case 'SET_HOMETEAM_SCORE':
+      return {
+        ...state,
+        score: { ...state.score, homeTeam: action.score },
+      };
   }
 };
 
@@ -109,6 +125,10 @@ export function TicketFormProvider({
     stadium: ticketFormState.stadium,
     myTeam: undefined,
     opponentTeam: undefined,
+    score: {
+      homeTeam: 0,
+      awayTeam: 0,
+    },
   });
 
   return (

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Button from '@components/common/Button';
 import SetAwayTeam from '@components/SetAwayTeam';
 import SetMatchDate from '@components/SetMatchDate';
+import SetMatchScore from '@components/SetMatchScore';
 import SetMatchSeason from '@components/SetMatchSeason';
 import SetMyTeam from '@components/SetMyTeam';
 import { useTicketForm } from '@context/TicketFormContext';
@@ -18,6 +19,8 @@ function renderTicketRegisterForm(step: number) {
       return <SetAwayTeam />;
     case 4:
       return <SetMyTeam />;
+    case 5:
+      return <SetMatchScore />;
   }
 }
 


### PR DESCRIPTION
## What is this PR?

close #61

## Changes

- 스코어 입력 값에는 기본값인 0도 포함될 수 있으므로, 다른 단계와 달리 유효성 검사 로직을 추가하지 않음.
- `scoreType` 값은 추후 db에 저장하려고 생각 중이어서,
사용자가 입력한 스코어 값을 바탕으로 하여 값을 리턴하는 함수를 만들어 결과값을 저장함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/194585981-a0cd138e-a90f-477d-9589-13bf52c4674c.png" width="50%" > |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194586055-7b763238-bc1a-4596-abfd-74e675579357.png" width="50%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194586142-affffb5d-35c7-4e60-a2dc-40b357338997.png" width="50%"> |

## Test Checklist

- [x] 스코어 입력 박스에 숫자만 입력 가능 확인
- [x] `scoreType` 값이 올바르게 저장되는지 확인

## Etc

티켓 등록에 필요한 마지막 단계. `submit` 버튼은 다음 작업에 추가 예정.