### PR TITLE
Feat: 티켓 등록 폼 현재 단계 표시하는 진행바 추가

### DIFF
--- a/src/components/ProgressIndicator/index.tsx
+++ b/src/components/ProgressIndicator/index.tsx
@@ -1,0 +1,38 @@
+import { colors } from '@styles/theme';
+import { styles } from './styles';
+
+interface Props {
+  step: number;
+  stepTitles: string[];
+}
+
+export default function ProgressIndicator({ step, stepTitles }: Props) {
+  const progressWidth =
+    step == stepTitles.length
+      ? '100%'
+      : `${(step - 1) * (100 / (stepTitles.length - 1))}%`;
+
+  return (
+    <div css={styles.progressIndicator}>
+      <div
+        css={styles.progressBar}
+        style={{ '--progress-width': progressWidth }}
+      />
+      {stepTitles.map((title, index) => (
+        <div
+          key={title}
+          css={styles.progressBullet}
+          style={{
+            '--bullet-bg':
+              index + 1 < step ? colors.indigo[300] : colors.indigo[50],
+            '--bullet-border':
+              index + 1 <= step
+                ? `2px solid ${colors.indigo[300]}`
+                : '2px solid transparent',
+          }}
+          data-title={title}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProgressIndicator/styles.ts
+++ b/src/components/ProgressIndicator/styles.ts
@@ -1,0 +1,72 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  progressIndicator: css({
+    position: 'relative',
+    display: 'flex',
+    justifyContent: 'space-between',
+    margin: '1rem 0',
+    counterReset: 'step',
+    '&:before': {
+      zIndex: '-1',
+      content: '""',
+      position: 'absolute',
+      top: '50%',
+      transform: 'translateY(-50%)',
+      height: 4,
+      width: '100%',
+      background: colors.indigo[50],
+    },
+    [mq('sm')]: {
+      margin: '2rem 0 1em',
+    },
+  }),
+  progressBar: css({
+    zIndex: '-1',
+    position: 'absolute',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    height: 4,
+    width: 'var(--progress-width)',
+    background: colors.indigo[300],
+    transition: '.5s',
+  }),
+  progressBullet: css({
+    position: 'relative',
+    width: 25,
+    height: 25,
+    borderRadius: '50%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    background: 'var(--bullet-bg)',
+    border: 'var(--bullet-border)',
+    color: colors.white,
+    fontSize: '1rem',
+    transition: '.5s',
+    '&:before': {
+      counterIncrement: 'step',
+      content: 'counter(step)',
+    },
+    '&:after': {
+      display: 'none',
+      content: 'attr(data-title)',
+      position: 'absolute',
+      bottom: 'calc(100% + 1rem)',
+      width: 'calc(100% + 2rem)',
+      textAlign: 'center',
+      color: colors.black,
+      fontSize: '0.875rem',
+    },
+    [mq('sm')]: {
+      width: 40,
+      height: 40,
+      fontSize: '1.6rem',
+      '&:after': {
+        display: 'block',
+      },
+    },
+  }),
+};

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@components/common/Button';
+import ProgressIndicator from '@components/ProgressIndicator';
 import SetAwayTeam from '@components/SetAwayTeam';
 import SetMatchDate from '@components/SetMatchDate';
 import SetMatchScore from '@components/SetMatchScore';
@@ -23,6 +24,8 @@ function renderTicketRegisterForm(step: number) {
       return <SetMatchScore />;
   }
 }
+
+const stepTitles = ['시즌', '경기 날짜', '매치업', '응원팀', '스코어'];
 
 export default function TicketRegister() {
   const [formStep, setFormStep] = useState(1);
@@ -66,6 +69,7 @@ export default function TicketRegister() {
   return (
     <section css={styles.wrapper}>
       <h2>티켓 등록</h2>
+      <ProgressIndicator step={formStep} stepTitles={stepTitles} />
       <form>
         {renderTicketRegisterForm(formStep)}
         <div css={styles.formNavigation}>


### PR DESCRIPTION
## What is this PR?

close #63 

## Changes

- 작은 화면에서 해당 단계의 타이틀을 포함하게 되면, 화면에 렌더링되는 폼의 가독성이 좋지 않아 태블릿 이상의 크기에서만 표시함.

- 최대한 props를 넘기지 않고 동적인 스타일을 적용하기 위해 var 변수를 활용함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile |  <img src="https://user-images.githubusercontent.com/37580351/194721378-d38d16aa-391b-4ba5-970a-4f5417fe1fcb.png" width="50%">  |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194721406-eede38cb-e1b7-4041-a15a-205476e12b94.png" width="50%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194721427-7a4915ce-95ad-467c-81fc-529e37f7fdc6.png" width="50%"> |

## Test Checklist

- [x] 단계 이동시, 진행바 bullet에 적용된 `border`, `background`, `transition` 속성 적용 확인

## Etc

- 마크업 코드 대신 css counter, 가상 선택자의 사용
리액트에서 map을 이용해 리스트를 렌더링할 때, 인덱스 값을 가져와서 별도의 코드를 작성하지 않아도 된다는 장점이 있음.
현재 코드에는 큰 효과는 없었지만, 중첩된 상위 인덱스의 값을 필요로 하는 경우에 요긴하게 쓰일 수 있을 것 같음.