### PR TITLE
Design: ProgressIndicator 단계 타이틀 bullet 하단으로 위치 변경

### DIFF
--- a/src/components/ProgressIndicator/styles.ts
+++ b/src/components/ProgressIndicator/styles.ts
@@ -20,7 +20,7 @@ export const styles = {
       background: colors.indigo[50],
     },
     [mq('sm')]: {
-      margin: '2rem 0 1em',
+      margin: '1rem 0 2rem',
     },
   }),
   progressBar: css({
@@ -54,7 +54,7 @@ export const styles = {
       display: 'none',
       content: 'attr(data-title)',
       position: 'absolute',
-      bottom: 'calc(100% + 1rem)',
+      top: 'calc(100% + 1rem)',
       width: 'calc(100% + 2rem)',
       textAlign: 'center',
       color: colors.black,


### PR DESCRIPTION
## What is this PR?

#64 코드 변경

## Changes

텍스트로 표현된 타이틀을 bullet 상단에서 하단으로 위치 수정함.
다른 곳에 사용될 때도 감안하여, 텍스트가 상단에 위치하는 것이 생각보다 가독성이 좋지 않아 변경함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 변경 전 | <img src="https://user-images.githubusercontent.com/37580351/194740574-12ac2cf4-ad76-4bd9-b7ed-96c9dd9dc6b2.png" width="50%" /> |
| 변경 후 | <img src="https://user-images.githubusercontent.com/37580351/194740573-23505708-1292-4f8d-9b61-a1dafa1118d3.png" width="50%" /> |

## Test Checklist

없음

## Etc

없음
