### PR TITLE
Design: 티켓 등록 단계 컴포넌트들 스타일 변경

### DIFF
--- a/src/components/SetAwayTeam/styles.ts
+++ b/src/components/SetAwayTeam/styles.ts
@@ -13,10 +13,9 @@ export const styles = {
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
-      justifyContent: 'space-around',
+      justifyContent: 'space-evenly',
       background: colors.gray[50],
       borderRadius: 8,
-      padding: '1rem',
       margin: '0 0 1rem 1rem',
       em: {
         fontWeight: 600,

--- a/src/components/SetMatchDate/styles.ts
+++ b/src/components/SetMatchDate/styles.ts
@@ -3,5 +3,10 @@ import { css } from '@emotion/react';
 export const styles = {
   selectCalendar: css({
     display: 'flex',
+    marginLeft: '-1rem',
+    '> div': {
+      flex: '0 1 33.33%',
+      margin: '0 0 1rem 1rem',
+    },
   }),
 };

--- a/src/components/SetMatchSeason/index.tsx
+++ b/src/components/SetMatchSeason/index.tsx
@@ -6,11 +6,6 @@ import {
 } from '@context/TicketFormContext';
 import { styles } from './styles';
 
-interface RadioButtonGroupProps {
-  checkedValue: string;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-}
-
 const KBO_LEAGUE_SEASONS = ['정규시즌', '포스트시즌'];
 
 export default function SetMatchSeason() {
@@ -24,29 +19,20 @@ export default function SetMatchSeason() {
   return (
     <div>
       <h3>경기 시즌을 선택하세요</h3>
-      <RadioButtonGroup
-        checkedValue={matchSeason}
-        onChange={onChangeMatchSeason}
-      />
+      <div css={styles.radioButtonWrapper}>
+        {KBO_LEAGUE_SEASONS.map(season => (
+          <RadioButton
+            key={season}
+            id={season}
+            value={season}
+            name="season"
+            checked={season == matchSeason}
+            onChange={onChangeMatchSeason}
+            label={season}
+          />
+        ))}
+      </div>
       {matchSeason == '포스트시즌' && <SetMatchSeries />}
-    </div>
-  );
-}
-
-function RadioButtonGroup({ checkedValue, onChange }: RadioButtonGroupProps) {
-  return (
-    <div css={styles.radioButtonWrapper}>
-      {KBO_LEAGUE_SEASONS.map(season => (
-        <RadioButton
-          key={season}
-          id={season}
-          value={season}
-          name="season"
-          checked={checkedValue == season}
-          onChange={onChange}
-          label={season}
-        />
-      ))}
     </div>
   );
 }

--- a/src/components/SetMatchSeries/index.tsx
+++ b/src/components/SetMatchSeries/index.tsx
@@ -5,11 +5,6 @@ import {
 } from '@context/TicketFormContext';
 import { styles } from './styles';
 
-interface RadioButtonGroupProps {
-  checkedValue: string;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-}
-
 const KBO_POSTSEASON_SERIES = [
   '와일드카드 결정전',
   '준플레이오프',
@@ -28,28 +23,19 @@ export default function SetMatchSeries() {
   return (
     <div>
       <h3>시리즈를 선택하세요</h3>
-      <RadioButtonGroup
-        checkedValue={matchSeries}
-        onChange={onChangeMatchSeries}
-      />
-    </div>
-  );
-}
-
-function RadioButtonGroup({ checkedValue, onChange }: RadioButtonGroupProps) {
-  return (
-    <div css={styles.radioButtonWrapper}>
-      {KBO_POSTSEASON_SERIES.map(series => (
-        <RadioButton
-          key={series}
-          id={series}
-          value={series}
-          name="series"
-          checked={checkedValue == series}
-          onChange={onChange}
-          label={series}
-        />
-      ))}
+      <div css={styles.radioButtonWrapper}>
+        {KBO_POSTSEASON_SERIES.map(series => (
+          <RadioButton
+            key={series}
+            id={series}
+            value={series}
+            name="series"
+            checked={matchSeries == series}
+            onChange={onChangeMatchSeries}
+            label={series}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/SetMyTeam/styles.ts
+++ b/src/components/SetMyTeam/styles.ts
@@ -12,11 +12,11 @@ export const styles = {
     },
   }),
   team: css({
-    height: 114,
+    height: 150,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    justifyContent: 'space-around',
+    justifyContent: 'space-evenly',
     em: {
       fontWeight: 600,
       fontSize: '1.4rem',

--- a/src/components/common/RadioButton/styles.ts
+++ b/src/components/common/RadioButton/styles.ts
@@ -24,7 +24,10 @@ export const styles = {
     },
     label: {
       flex: '1 1 auto',
-      padding: '1rem',
+      minHeight: 60,
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
       border: `1px solid ${colors.gray[200]}`,
       borderRadius: 8,
       background: colors.white,


### PR DESCRIPTION
## What is this PR?

close #65 

## Changes

- 날짜 선택 단계에서 드롭다운 박스 간에 여백 추가

- 공통 컴포넌트 `RadioButton` 안의 라벨 텍스트 가운데 정렬 방식 변경
원정팀, 응원팀 선택 단계에서 박스 높이를 맞출 때,
padding 값으로 인해 높이를 맞추려면 padding을 제외한 값을 계산해야 해서 padding을 제외함.

- RadioButtonGroups 컴포넌트 삭제
재사용이 어렵고, 굳이 컴포넌트로 분리할 필요가 없어 다시 원래 마크업 코드로 변경함.
 
## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음
