### PR TITLE
Feat: 등록한 티켓 마지막 확인 단계 추가

### DIFF
--- a/src/components/ConfirmTicket/index.tsx
+++ b/src/components/ConfirmTicket/index.tsx
@@ -1,8 +1,15 @@
 import { KBO_LEAGUE_TEAMS } from '@constants/global';
 import { useTicketForm } from '@context/TicketFormContext';
+import { colors } from '@styles/theme';
 import { styles } from './styles';
 
 const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+
+const scoreTypes = {
+  승: colors.indigo[800],
+  패: colors.red[800],
+  무: colors.gray[800],
+};
 
 export default function ConfirmTicket() {
   const {
@@ -29,7 +36,9 @@ export default function ConfirmTicket() {
             <span>
               {score.awayTeam} : {score.homeTeam}
             </span>
-            <em>{scoreType}</em>
+            <em style={{ '--score-type': scoreTypes[scoreType] }}>
+              {scoreType}
+            </em>
           </p>
           <p
             css={styles.matchup}

--- a/src/components/ConfirmTicket/index.tsx
+++ b/src/components/ConfirmTicket/index.tsx
@@ -1,0 +1,48 @@
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import { useTicketForm } from '@context/TicketFormContext';
+import { styles } from './styles';
+
+const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+
+export default function ConfirmTicket() {
+  const {
+    matchDate: { year, month, date },
+    homeTeam,
+    awayTeam,
+    stadium,
+    score,
+    scoreType,
+  } = useTicketForm();
+  const matchDate = `${year}.${month}.${date}`;
+  const matchDay = weekdays[new Date(year, month - 1, date).getDay()];
+  const matchup = `${awayTeam && KBO_LEAGUE_TEAMS[awayTeam]} vs ${
+    homeTeam && KBO_LEAGUE_TEAMS[homeTeam]
+  }`;
+
+  return (
+    <div>
+      <h3>티켓 정보</h3>
+      <div css={styles.ticketWrapper}>
+        <div css={styles.ticket}>
+          <p css={styles.title}>{year} KBO 리그</p>
+          <p css={styles.score}>
+            <span>
+              {score.awayTeam} : {score.homeTeam}
+            </span>
+            <em>{scoreType}</em>
+          </p>
+          <p
+            css={styles.matchup}
+            style={{ '--home-logo': `url('images/team/${homeTeam}.png')` }}
+          >
+            {matchup}
+          </p>
+          <p css={styles.date}>
+            {matchDate} ({matchDay})
+          </p>
+          <p css={styles.stadium}>{stadium}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ConfirmTicket/styles.ts
+++ b/src/components/ConfirmTicket/styles.ts
@@ -63,7 +63,7 @@ export const styles = {
       transform: 'translateY(-50%)',
       width: 30,
       height: 30,
-      background: colors.indigo[800],
+      background: 'var(--score-type)',
       color: colors.white,
       borderRadius: '50%',
     },

--- a/src/components/ConfirmTicket/styles.ts
+++ b/src/components/ConfirmTicket/styles.ts
@@ -1,0 +1,104 @@
+import { css } from '@emotion/react';
+import { mq } from '@styles/mediaQueries';
+import { colors } from '@styles/theme';
+
+export const styles = {
+  ticketWrapper: css({
+    padding: '2rem 0.5rem',
+    borderRadius: 4,
+    background: colors.gray[100],
+  }),
+  ticket: css({
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    background: colors.white,
+    borderRadius: 8,
+    '&:before, &:after': {
+      zIndex: 10,
+      content: '""',
+      position: 'absolute',
+      top: 50,
+      border: `10px solid ${colors.gray[100]}`,
+      transform: 'rotate(-45deg)',
+    },
+    '&:before': {
+      left: '-10px',
+      borderTopColor: 'transparent',
+      borderLeftColor: 'transparent',
+    },
+    '&:after': {
+      right: '-10px',
+      borderRightColor: 'transparent',
+      borderBottomColor: 'transparent',
+    },
+    '> p': {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    [mq('xs')]: {
+      maxWidth: 300,
+      margin: '0 auto',
+    },
+  }),
+  title: css({
+    height: 60,
+    fontWeight: 600,
+    borderBottom: `4px dotted ${colors.gray[300]}`,
+  }),
+  score: css({
+    '> *': {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    span: {
+      height: 120,
+      fontSize: '3.6rem',
+      fontWeight: 600,
+    },
+    em: {
+      transform: 'translateY(-50%)',
+      width: 30,
+      height: 30,
+      background: colors.indigo[800],
+      color: colors.white,
+      borderRadius: '50%',
+    },
+  }),
+  matchup: css({
+    position: 'relative',
+    height: 60,
+    fontSize: '1.4rem',
+    fontWeight: 600,
+    '&:before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      backgroundImage: 'var(--home-logo)',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: '50% 50%',
+      opacity: '.2',
+    },
+  }),
+  date: css({
+    height: 60,
+    fontSize: '1.2rem',
+  }),
+  stadium: css({
+    height: 60,
+    color: colors.gray[600],
+    '&:before': {
+      content: '""',
+      width: 200,
+      height: 1,
+      transform: 'translateY(-1rem)',
+      background: colors.gray[300],
+    },
+  }),
+};

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -25,7 +25,7 @@ interface TicketFormContext {
     homeTeam: number;
     awayTeam: number;
   };
-  scoreType: string;
+  scoreType: ReturnType<typeof getScoreType>;
 }
 
 type TicketFormActions =

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -64,6 +64,8 @@ export default function TicketRegister() {
       if (myTeam && opponentTeam) return true;
       return false;
     }
+
+    return true;
   }
 
   return (

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@components/common/Button';
+import ConfirmTicket from '@components/ConfirmTicket';
 import ProgressIndicator from '@components/ProgressIndicator';
 import SetAwayTeam from '@components/SetAwayTeam';
 import SetMatchDate from '@components/SetMatchDate';
@@ -22,10 +23,12 @@ function renderTicketRegisterForm(step: number) {
       return <SetMyTeam />;
     case 5:
       return <SetMatchScore />;
+    case 6:
+      return <ConfirmTicket />;
   }
 }
 
-const stepTitles = ['시즌', '경기 날짜', '매치업', '응원팀', '스코어'];
+const stepTitles = ['시즌', '경기 날짜', '매치업', '응원팀', '스코어', '등록'];
 
 export default function TicketRegister() {
   const [formStep, setFormStep] = useState(1);

--- a/src/pages/TicketRegister/index.tsx
+++ b/src/pages/TicketRegister/index.tsx
@@ -32,6 +32,7 @@ const stepTitles = ['시즌', '경기 날짜', '매치업', '응원팀', '스코
 
 export default function TicketRegister() {
   const [formStep, setFormStep] = useState(1);
+  const lastStep = stepTitles.length;
   const ticketForm = useTicketForm();
 
   function prevStep() {
@@ -85,13 +86,20 @@ export default function TicketRegister() {
           >
             이전
           </Button>
-          <Button
-            onClick={nextStep}
-            disabled={!validateForm()}
-            bgColor={colors.indigo[600]}
-          >
-            다음
-          </Button>
+          {formStep != lastStep && (
+            <Button
+              onClick={nextStep}
+              disabled={!validateForm()}
+              bgColor={colors.indigo[600]}
+            >
+              다음
+            </Button>
+          )}
+          {formStep == lastStep && (
+            <Button type="submit" bgColor={colors.indigo[600]}>
+              등록
+            </Button>
+          )}
         </div>
       </form>
     </section>


### PR DESCRIPTION
## What is this PR?

close #69 

## Changes

- 폼 유효성 함수 기본값 변경 undefined → `true` 변경
스코어 입력 단계는 기본 입력값이 유효하며, 이후 단계는 등록한 티켓을 확인만 하는 단계이므로 검사가 필요하지 않음.

- 경기 정보에 대한 기본적인 정보에 부가적으로 자신의 응원팀 결과도 추가하여
사용자가 자신이 응원하는 팀의 결과가 어떤지도 확인할 수 있도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/194806191-23c73b43-d0ab-45f8-85dc-b707e347436c.png" width="50%"> |
| tablet | <img src="https://user-images.githubusercontent.com/37580351/194806189-ca0eaeb5-b1fb-4b8c-952b-fc9ec4a38ef9.png" width="50%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/194806185-3a65de27-1603-44aa-bcff-b8edbc6370a6.png" width="50%" > |

## Test Checklist

- [x] 응원팀 승패 결과에 따라 스코어 타입 배경색 변경되는지 확인

## Etc

없음
