### PR TITLE
Feat(css-prop): `Button` 컴포넌트 스타일 적용 방식 변경

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -5,23 +5,8 @@ import { styles } from './styles';
 interface Props {
   fullWidth?: boolean;
   bgColor?: string;
-  size?: keyof typeof sizes;
+  size?: 'small' | 'medium' | 'large';
 }
-
-const sizes = {
-  small: {
-    height: '1.5rem',
-    fontSize: '.875rem',
-  },
-  medium: {
-    height: '2.25rem',
-    fontSize: '1rem',
-  },
-  large: {
-    height: '3rem',
-    fontSize: '1.25rem',
-  },
-} as const;
 
 export default function Button({
   children,
@@ -33,11 +18,9 @@ export default function Button({
   return (
     <button
       type="button"
-      css={styles.button}
+      css={[styles.button, styles[size]]}
       style={{
         ['--button-width']: fullWidth ? '100%' : 'auto',
-        ['--button-height']: sizes[size].height,
-        ['--button-fontSize']: sizes[size].fontSize,
         ['--button-color']: bgColor ? colors.white : colors.black,
         ['--button-bg']: bgColor || 'transparent',
       }}

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,28 +1,27 @@
 import * as React from 'react';
-import { colors } from '@styles/theme';
 import { styles } from './styles';
 
 interface Props {
   fullWidth?: boolean;
   bgColor?: string;
   size?: 'small' | 'medium' | 'large';
+  variant?: 'primary' | 'secondary' | 'basic';
 }
 
 export default function Button({
   children,
   fullWidth,
-  bgColor,
+  // bgColor,
   size = 'medium',
+  variant = 'basic',
   ...props
 }: React.PropsWithChildren<Props> & React.ComponentPropsWithRef<'button'>) {
   return (
     <button
       type="button"
-      css={[styles.button, styles[size]]}
+      css={[styles.button, styles[size], styles[variant]]}
       style={{
         ['--button-width']: fullWidth ? '100%' : 'auto',
-        ['--button-color']: bgColor ? colors.white : colors.black,
-        ['--button-bg']: bgColor || 'transparent',
       }}
       {...props}
     >

--- a/src/components/common/Button/styles.ts
+++ b/src/components/common/Button/styles.ts
@@ -10,6 +10,7 @@ export const styles = {
     fontWeight: 600,
     '&:disabled': {
       cursor: 'not-allowed',
+      color: colors.gray[400],
     },
   }),
   small: css({
@@ -28,6 +29,10 @@ export const styles = {
     background: colors.indigo[600],
     color: colors.white,
     border: `1px solid ${colors.indigo[600]}`,
+    '&:disabled': {
+      background: colors.gray[200],
+      borderColor: colors.gray[200],
+    },
   }),
   secondary: css({
     background: colors.white,

--- a/src/components/common/Button/styles.ts
+++ b/src/components/common/Button/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { colors } from '@styles/theme';
 
 export const styles = {
   button: css({
@@ -6,8 +7,6 @@ export const styles = {
     paddingLeft: '1rem',
     paddingRight: '1rem',
     borderRadius: 4,
-    color: 'var(--button-color)',
-    backgroundColor: 'var(--button-bg)',
     fontWeight: 600,
     '&:disabled': {
       cursor: 'not-allowed',
@@ -24,5 +23,21 @@ export const styles = {
   large: css({
     height: '3rem',
     fontSize: '1.25rem',
+  }),
+  primary: css({
+    background: colors.indigo[600],
+    color: colors.white,
+    border: `1px solid ${colors.indigo[600]}`,
+  }),
+  secondary: css({
+    background: colors.white,
+    color: colors.indigo[600],
+    border: `1px solid ${colors.gray[200]}`,
+    boxShadow: '0 2px 6px rgba(0,0,0,0.05)',
+  }),
+  basic: css({
+    background: 'transparent',
+    color: colors.black,
+    border: 'none',
   }),
 };

--- a/src/components/common/Button/styles.ts
+++ b/src/components/common/Button/styles.ts
@@ -3,16 +3,26 @@ import { css } from '@emotion/react';
 export const styles = {
   button: css({
     width: 'var(--button-width)',
-    height: 'var(--button-height)',
     paddingLeft: '1rem',
     paddingRight: '1rem',
     borderRadius: 4,
     color: 'var(--button-color)',
     backgroundColor: 'var(--button-bg)',
     fontWeight: 600,
-    fontSize: 'var(--button-fontSize)',
     '&:disabled': {
       cursor: 'not-allowed',
     },
+  }),
+  small: css({
+    height: '1.5rem',
+    fontSize: '.875rem',
+  }),
+  medium: css({
+    height: '2.25rem',
+    fontSize: '1rem',
+  }),
+  large: css({
+    height: '3rem',
+    fontSize: '1.25rem',
   }),
 };


### PR DESCRIPTION
## What is this PR?

close #71

## Changes

```javascript
<Button bgColor="black" /> // 기존 방식
<Button variant="primary" /> // 변경 방식
```

### 1. 기존의 props로 받은 값을 css var 변수로 처리할 때, 많은 속성값이 인라인 속성으로 적용됨.
props로 받은 값을 var 변수로 처리하지 않고 각각의 css prop 스타일 객체 프로퍼티로 만들어,
이 값을 버튼 컴포넌트의 css prop에 배열 형태로 전달함.

props의 타입이 유니온 타입으로 구체적으로 지정되어 있기 때문에, 타입 추론이 잘 되며,
var 변수보다 원하는 속성을 더 자유롭게 적용할 수 있음. 

### 2. 버튼의 디자인 형태를 변경하려면, 사용하는 컴포넌트에서 스타일 속성을 별도로 적용해야 함.
배경색을 props로 전달하지 않고, 버튼의 디자인 타입 `variant` 값을 전달받아 버튼의 모양과 색을 결정함.

*var 변수를 사용해 버튼의 색상을 주입할 수 있으나, 일단 코드는 추가하지 않음.

```javascript
<button css={[styles.button, styles[size], styles[variant]]} />
```

단, css prop 간에 공통 속성 프로퍼티가 없어야 원하는 스타일 속성이 잘 적용됨.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| primary | ![primary](https://user-images.githubusercontent.com/37580351/194857833-b74ec997-1ef1-4d73-847d-816d0b143fdc.png) |
| secondary | ![secondary](https://user-images.githubusercontent.com/37580351/194857830-b52d5750-b2c8-4d68-b165-73fee171e391.png) |
| basic | ![basic](https://user-images.githubusercontent.com/37580351/194857824-78ea14c1-26f5-4c1e-a42d-5eacbde632ab.png) |

## Test Checklist

없음

## Etc

`bgColor` 값이 주석처리 된 것은 사용하지 않는 값이 eslint 검사에 걸려 커밋이 안됨.
버튼 컴포넌트를 사용한 다른 컴포넌트들의 값을 수정할 때, 삭제할 예정.