### PR TITLE
Fix: 루트 경로로 이미지 경로 수정

### DIFF
--- a/src/components/ConfirmTicket/index.tsx
+++ b/src/components/ConfirmTicket/index.tsx
@@ -42,7 +42,7 @@ export default function ConfirmTicket() {
           </p>
           <p
             css={styles.matchup}
-            style={{ '--home-logo': `url('images/team/${homeTeam}.png')` }}
+            style={{ '--home-logo': `url('/images/team/${homeTeam}.png')` }}
           >
             {matchup}
           </p>


### PR DESCRIPTION
## What is this PR?

close #79 

## Changes

변경 전 경로는 현재 경로를 앞에 붙이기 때문에,
중첩 라우트 경로의 페이지에서 이미지를 불러올 경우 문제가 됨.

루트 경로로 변경하여 페이지 url 경로에 상관없이 동일 경로에서 이미지를 불러오도록 수정함.

## Screenshot

| 기능 | 스크린샷 |
| :----: | :---------: |
| 변경 후 화면 | <img src="https://user-images.githubusercontent.com/37580351/195370034-15c5713d-25ee-4691-b269-882a123b9da1.png" width="30%">|
| 네트워크 요청탭 결과 | ![제목 없음](https://user-images.githubusercontent.com/37580351/195370826-20ba8873-d628-44f1-bb3b-32aeffa0c52f.png) |

## Test Checklist

스크린샷 참고

## Etc

사실 이전에 코드 작성시 빼먹어서 생긴 버그이지만,
중첩 라우터 경로를 생성하면서 `/` 를 하나 빼먹은 것이 어떤 오류를 발생시킬 수 있는지 알게 됨.
