### PR TITLE
Fix: 홈팀 정보 params로 처리 후, 올바르지 않은 params는 페이지 네비게이션 처리

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -21,7 +21,7 @@ export default function Router() {
             <Route path="register">
               <Route index element={<StadiumPicker />} />
               <Route
-                path=":team"
+                path=":teamId"
                 element={
                   <TicketFormProvider>
                     <TicketRegister />

--- a/src/components/SetAwayTeam/index.tsx
+++ b/src/components/SetAwayTeam/index.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import RadioButton from '@components/common/RadioButton';
-import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import { KBO_LEAGUE_TEAMS, KBOTeams } from '@constants/global';
 import {
-  type TicketFormLocationState,
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
@@ -17,22 +16,24 @@ interface AwayTeamListProps {
 }
 
 export default function SetAwayTeam() {
-  const location = useLocation();
-  const ticketFormState = location.state as TicketFormLocationState;
+  const params = useParams<'teamId'>();
+  const awayTeamsExcludingHomeTeam = KBOTeams.filter(
+    ([teamId]) => teamId !== params.teamId
+  );
 
   const ticketFormDispatch = useTicketFormDispatch();
   const { homeTeam, awayTeam } = useTicketForm();
   const [awayTeams, setAwayTeams] = useState(() => {
-    if (awayTeam)
-      return ticketFormState.awayTeams.filter(team => team[0] != awayTeam);
-    return ticketFormState.awayTeams;
+    return awayTeam
+      ? awayTeamsExcludingHomeTeam.filter(([teamId]) => teamId != awayTeam)
+      : awayTeamsExcludingHomeTeam;
   });
 
   function onChangeAwayTeam(
     e: React.ChangeEvent<HTMLInputElement & { value: TeamId }>
   ) {
-    const changedAwayTeams = ticketFormState.awayTeams.filter(
-      awayTeam => awayTeam[0] != e.target.value
+    const changedAwayTeams = awayTeamsExcludingHomeTeam.filter(
+      ([teamId]) => teamId != e.target.value
     );
     setAwayTeams(changedAwayTeams);
     ticketFormDispatch({

--- a/src/components/StadiumList/index.tsx
+++ b/src/components/StadiumList/index.tsx
@@ -6,10 +6,6 @@ import {
 } from '@constants/global';
 import { styles } from './styles';
 
-function getAwayTeams(teamId: string) {
-  return KBOTeams.filter(team => team[0] !== teamId);
-}
-
 export default function StadiumList() {
   return (
     <ul css={styles.stadiumList}>
@@ -27,16 +23,7 @@ export default function StadiumList() {
           >
             <em>{teamFullName}</em>
             <em>{homeStadium}</em>
-            <Link
-              to={teamId}
-              state={{
-                homeTeam: [...team],
-                awayTeams: getAwayTeams(teamId),
-                stadium: homeStadium,
-              }}
-            >
-              티켓 등록
-            </Link>
+            <Link to={teamId}>티켓 등록</Link>
           </li>
         );
       })}

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useReducer } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import { KBO_LEAGUE_STADIUMS, KBOTeams } from '@constants/global';
 import { TeamId } from '@typings/db';
 
@@ -147,6 +148,10 @@ export function TicketFormProvider({
     },
     scoreType: '무',
   });
+
+  if (!isTeamId(params.teamId)) {
+    return <Navigate to="/register" replace />;
+  }
 
   return (
     <TicketFormDispatchContext.Provider value={dispatch}>

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -1,12 +1,6 @@
 import { createContext, useContext, useReducer } from 'react';
-import { useLocation } from 'react-router-dom';
-import { TeamId, Teams } from '@typings/db';
-
-export interface TicketFormLocationState {
-  homeTeam: Teams[number];
-  awayTeams: Teams;
-  stadium: string;
-}
+import { KBO_LEAGUE_STADIUMS, KBOTeams } from '@constants/global';
+import { TeamId } from '@typings/db';
 
 interface TicketFormContext {
   matchDate: {
@@ -125,19 +119,26 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
   }
 };
 
+function isTeamId(id: string | undefined): id is TeamId {
+  return KBOTeams.some(([teamId]) => teamId == id);
+}
+
 export function TicketFormProvider({
   children,
 }: React.PropsWithChildren<unknown>) {
-  const location = useLocation();
-  const ticketFormState = location.state as TicketFormLocationState;
+  const params = useParams<'teamId'>();
+  const homeTeam = {
+    teamId: isTeamId(params.teamId) ? params.teamId : undefined,
+    stadium: isTeamId(params.teamId) ? KBO_LEAGUE_STADIUMS[params.teamId] : '',
+  };
 
   const [state, dispatch] = useReducer(ticketFormReducer, {
     matchDate: { year: 0, month: 0, date: 0 },
     matchSeason: '',
     matchSeries: '',
-    homeTeam: ticketFormState.homeTeam[0],
+    homeTeam: homeTeam.teamId,
     awayTeam: undefined,
-    stadium: ticketFormState.stadium,
+    stadium: homeTeam.stadium,
     myTeam: undefined,
     opponentTeam: undefined,
     score: {


### PR DESCRIPTION
## What is this PR?

close #57 

## Changes

각 구장의 티켓 등록 페이지 링크로 직접 진입하고자 하는 경우에는
링크 버튼에서 가져오는 홈팀 정보를 가져올 수 없기 때문에 오류가 발생할 수 있음.

params 객체로 id 값을 가져와서, 직접 링크 주소로 진입하고자 하는 경우에도 티켓 등록이 가능하게 함. 

단, teamId가 아님에도 teamId로 값이 허용되어 티켓 등록 페이지로 진입하는 것을 막기 위해
커스텀 타입 검사 함수 `isTeamId` 를 통해 teamId 값 검사를 일차적으로 실행하고,
일치하면 티켓 등록 폼으로 연결되며, 일치하지 않으면 구장을 선택하는 페이지로 연결함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

- [x] `/register/OB` 진입시, 두산의 홈구장 잠실야구장에서의 티켓 등록 폼 페이지로 연결됨 확인
- [x] `/register/MB` 진입시, 티켓 등록 구장 선택 페이지로 이동 확인

## Etc

타입을 `as`로 단언하는 방식보다 커스텀 타입 검사 함수를 생성하는 것이 
불확실한 값에 대해 타입을 분기처리할 수 있다는 장점이 있음.