### PR TITLE
Refactor(types): KBOTeams type Teams to TeamId[]

### DIFF
--- a/src/components/MyTeamList/index.tsx
+++ b/src/components/MyTeamList/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
 import { useTeamStore } from '@store/.';
 import { styles } from './styles';
 
@@ -16,10 +17,13 @@ export default function MyTeamList() {
   return (
     <div>
       <ul css={styles.teamList}>
-        {myTeams.map(myTeam => (
-          <li key={myTeam[0]} css={styles.team}>
+        {myTeams.map(teamId => (
+          <li key={teamId} css={styles.team}>
             <button>
-              <img src={`/images/team/${myTeam[0]}.png`} alt={myTeam[1]} />
+              <img
+                src={`/images/team/${teamId}.png`}
+                alt={KBO_LEAGUE_TEAMS[teamId]}
+              />
             </button>
           </li>
         ))}

--- a/src/components/PickTeamList/index.tsx
+++ b/src/components/PickTeamList/index.tsx
@@ -1,8 +1,9 @@
-import { Teams } from '@typings/db';
+import { KBO_LEAGUE_TEAMS } from '@constants/global';
+import { TeamId } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
-  teams: Teams;
+  teams: TeamId[];
 }
 
 export default function PickTeamList({ teams }: Props) {
@@ -12,12 +13,15 @@ export default function PickTeamList({ teams }: Props) {
 
   return (
     <ul css={styles.teamList}>
-      {teams.map((team, index) => (
-        <li key={team[0]}>
+      {teams.map((teamId, index) => (
+        <li key={teamId}>
           <button>
             <em>{index + 1}</em>
-            <img src={`/images/team/${team[0]}.png`} alt={team[1]} />
-            <span>{team[1]}</span>
+            <img
+              src={`/images/team/${teamId}.png`}
+              alt={KBO_LEAGUE_TEAMS[teamId]}
+            />
+            <span>{KBO_LEAGUE_TEAMS[teamId]}</span>
           </button>
         </li>
       ))}

--- a/src/components/SetAwayTeam/index.tsx
+++ b/src/components/SetAwayTeam/index.tsx
@@ -6,11 +6,11 @@ import {
   useTicketForm,
   useTicketFormDispatch,
 } from '@context/TicketFormContext';
-import { TeamId, Teams } from '@typings/db';
+import { TeamId } from '@typings/db';
 import { styles } from './styles';
 
 interface AwayTeamListProps {
-  list: Teams;
+  list: TeamId[];
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   checkedValue?: string;
 }
@@ -18,14 +18,14 @@ interface AwayTeamListProps {
 export default function SetAwayTeam() {
   const params = useParams<'teamId'>();
   const awayTeamsExcludingHomeTeam = KBOTeams.filter(
-    ([teamId]) => teamId !== params.teamId
+    teamId => teamId !== params.teamId
   );
 
   const ticketFormDispatch = useTicketFormDispatch();
   const { homeTeam, awayTeam } = useTicketForm();
   const [awayTeams, setAwayTeams] = useState(() => {
     return awayTeam
-      ? awayTeamsExcludingHomeTeam.filter(([teamId]) => teamId != awayTeam)
+      ? awayTeamsExcludingHomeTeam.filter(teamId => teamId != awayTeam)
       : awayTeamsExcludingHomeTeam;
   });
 
@@ -33,7 +33,7 @@ export default function SetAwayTeam() {
     e: React.ChangeEvent<HTMLInputElement & { value: TeamId }>
   ) {
     const changedAwayTeams = awayTeamsExcludingHomeTeam.filter(
-      ([teamId]) => teamId != e.target.value
+      teamId => teamId != e.target.value
     );
     setAwayTeams(changedAwayTeams);
     ticketFormDispatch({
@@ -51,9 +51,9 @@ export default function SetAwayTeam() {
             <>
               <img
                 src={`/images/team/${awayTeam}.png`}
-                alt={awayTeam && KBO_LEAGUE_TEAMS[awayTeam]}
+                alt={KBO_LEAGUE_TEAMS[awayTeam]}
               />
-              <em>{awayTeam && KBO_LEAGUE_TEAMS[awayTeam]}</em>
+              <em>{KBO_LEAGUE_TEAMS[awayTeam]}</em>
             </>
           ) : (
             <span>없음</span>
@@ -80,14 +80,14 @@ export default function SetAwayTeam() {
 function AwayTeamList({ list, onChange, checkedValue }: AwayTeamListProps) {
   return (
     <div css={styles.awayTeamList}>
-      {list.map(team => (
+      {list.map(teamId => (
         <RadioButton
-          key={team[0]}
-          id={team[0]}
-          value={team[0]}
-          checked={checkedValue == team[0]}
+          key={teamId}
+          id={teamId}
+          value={teamId}
+          checked={checkedValue == teamId}
           onChange={onChange}
-          label={team[1]}
+          label={KBO_LEAGUE_TEAMS[teamId]}
         />
       ))}
     </div>

--- a/src/components/StadiumList/index.tsx
+++ b/src/components/StadiumList/index.tsx
@@ -9,10 +9,9 @@ import { styles } from './styles';
 export default function StadiumList() {
   return (
     <ul css={styles.stadiumList}>
-      {KBOTeams.map(team => {
-        const teamId = team[0];
-        const teamFullName = KBO_LEAGUE_TEAMS_FULLNAME[team[0]];
-        const homeStadium = KBO_LEAGUE_STADIUMS[team[0]];
+      {KBOTeams.map(teamId => {
+        const teamFullName = KBO_LEAGUE_TEAMS_FULLNAME[teamId];
+        const homeStadium = KBO_LEAGUE_STADIUMS[teamId];
 
         return (
           <li

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -18,13 +18,10 @@ export default function TeamPicker() {
     >
   ) {
     if (e.target.checked) {
-      setPickedTeams(prev => [
-        ...prev,
-        [e.target.value, e.target.dataset.value],
-      ]);
+      setPickedTeams(prev => [...prev, e.target.value]);
     } else {
       setPickedTeams(prev =>
-        prev.filter(exTeam => exTeam[0] != e.target.value)
+        prev.filter(exTeamId => exTeamId != e.target.value)
       );
     }
   }
@@ -33,9 +30,7 @@ export default function TeamPicker() {
     const isChanged =
       myTeams.length !== pickedTeams.length ||
       (pickedTeams.length > 0 &&
-        pickedTeams.some(pickedTeam => {
-          return myTeams.findIndex(exTeam => exTeam == pickedTeam) == -1;
-        }));
+        pickedTeams.some(pickedTeam => myTeams.includes(pickedTeam)));
 
     if (isChanged) {
       changeMyTeams(pickedTeams);

--- a/src/components/TeamPickerList/index.tsx
+++ b/src/components/TeamPickerList/index.tsx
@@ -1,31 +1,27 @@
 import Checkbox from '@components/common/Checkbox';
-import { KBOTeams } from '@constants/global';
-import { TeamId, Teams } from '@typings/db';
+import { KBO_LEAGUE_TEAMS, KBOTeams } from '@constants/global';
+import { TeamId } from '@typings/db';
 import { styles } from './styles';
 
 interface Props {
-  teams: Teams;
+  teams: TeamId[];
   onChangeTeam: React.ChangeEventHandler<HTMLInputElement>;
-}
-
-function getTeamIsChecked(teams: Teams, teamId: TeamId) {
-  return teams.findIndex(team => team[0] == teamId) !== -1;
 }
 
 export default function TeamPickerList({ teams, onChangeTeam }: Props) {
   return (
     <ul css={styles.teamList}>
-      {KBOTeams.map(team => (
-        <li key={team[0]}>
-          <span style={{ '--team-logo': `url('/images/team/${team[0]}.png')` }}>
+      {KBOTeams.map(teamId => (
+        <li key={teamId}>
+          <span style={{ '--team-logo': `url('/images/team/${teamId}.png')` }}>
             <Checkbox
-              id={team[0]}
+              id={teamId}
               name="team"
-              value={team[0]}
-              checked={getTeamIsChecked(teams, team[0])}
+              value={teamId}
+              checked={teams.includes(teamId)}
               onChange={onChangeTeam}
-              label={team[1]}
-              data-value={team[1]}
+              label={KBO_LEAGUE_TEAMS[teamId]}
+              data-value={KBO_LEAGUE_TEAMS[teamId]}
             />
           </span>
         </li>

--- a/src/constants/global.ts
+++ b/src/constants/global.ts
@@ -1,4 +1,4 @@
-import { Teams } from '@typings/db';
+import { TeamId } from '@typings/db';
 
 export const BASE_URL = 'http://localhost:8080/api';
 
@@ -15,7 +15,7 @@ export const KBO_LEAGUE_TEAMS = {
   HH: '한화',
 } as const;
 
-export const KBOTeams = Object.entries(KBO_LEAGUE_TEAMS) as Teams;
+export const KBOTeams = Object.keys(KBO_LEAGUE_TEAMS) as TeamId[];
 
 export const KBO_LEAGUE_TEAMS_FULLNAME = {
   KT: 'KT 위즈',

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -121,7 +121,7 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
 };
 
 function isTeamId(id: string | undefined): id is TeamId {
-  return KBOTeams.some(([teamId]) => teamId == id);
+  return KBOTeams.some(teamId => teamId == id);
 }
 
 export function TicketFormProvider({

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -9,4 +9,3 @@ export interface User {
 
 export type TeamId = keyof typeof KBO_LEAGUE_TEAMS;
 export type TeamName = typeof KBO_LEAGUE_TEAMS[TeamId];
-export type Teams = Array<[TeamId, TeamName]>;


### PR DESCRIPTION
## What is this PR?

팀 리스트 배열 타입 변경

## Changes

- 기존 타입의 값: `[['OB', '두산], ['LT', '롯데']]`
- 바뀐 타입의 값: `['OB', 'LT']`

기존 타입으로 팀 리스트를 저장하여 사용하면, 서버에 저장된 형태와 다르기 때문에 재가공이 필요함.

`key` 역할을 할 수 있는 값을 팀 리스트에 저장함으로써,
최소한의 정보로 구단과 관련된 구장 정보, 실제 팀명 등의 정보를 가지고 오도록 함.
서버에 데이터를 전달할 때도 별도의 재가공이 필요하지 않음.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음
