### PR TITLE
Refactor: Login 컴포넌트 onSuccess props 내부 로직으로 변경

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,11 +7,8 @@ import Main from '@pages/Main';
 import StadiumPicker from '@pages/Register/StadiumPicker';
 import TicketForm from '@pages/Register/TicketForm';
 import RequireAuth from '@pages/RequireAuth';
-import { useUserStore } from './store';
 
 export default function Router() {
-  const loginUser = useUserStore(state => state.loginUser);
-
   return (
     <BrowserRouter>
       <Routes>
@@ -31,7 +28,7 @@ export default function Router() {
             </Route>
           </Route>
         </Route>
-        <Route path="login" element={<Login onSuccess={loginUser} />} />
+        <Route path="login" element={<Login />} />
         <Route path="authenticated" element={<Authenticated />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -8,10 +8,6 @@ import { useUserStore } from '@store/.';
 import { User } from '@typings/db';
 import { styles } from './styles';
 
-interface Props {
-  onSuccess(user: User): void;
-}
-
 interface ProviderProps {
   provider: Provider;
   Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
@@ -44,9 +40,10 @@ const providers = [
   },
 ] as const;
 
-export default function Login({ onSuccess }: Props) {
+export default function Login() {
   const navigate = useNavigate();
   const user = useUserStore(state => state.user);
+  const loginUser = useUserStore(state => state.loginUser);
   const newWindowRef = useRef<Window | null>();
   const prevWindowUrlRef = useRef('');
 
@@ -60,7 +57,7 @@ export default function Login({ onSuccess }: Props) {
       if (e.source == newWindowRef.current) {
         if (e.data.from == 'authentication') {
           if (e.data.user) {
-            onSuccess(e.data.user);
+            loginUser(e.data.user);
           } else {
             window.alert('로그인에 실패했습니다.');
           }
@@ -68,7 +65,7 @@ export default function Login({ onSuccess }: Props) {
         }
       }
     },
-    [onSuccess]
+    [loginUser]
   );
 
   function onClickLogin(provider: Provider) {


### PR DESCRIPTION
## What is this PR?

#75

## Changes

컴포넌트 외부에 함수를 두고 전달할 필요성이 없어 컴포넌트 내부 로직으로 변경함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 테스트 |  테스트  |

## Test Checklist

없음

## Etc

없음
