### PR TITLE
Feat(api): 티켓 등록 기능 구현

### DIFF
--- a/src/components/SnackBar/index.tsx
+++ b/src/components/SnackBar/index.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useSnackBarStore } from '@store/.';
+import { styles } from './styles';
+
+export default function SnackBar() {
+  const message = useSnackBarStore(state => state.message);
+  const clearSnackBar = useSnackBarStore(state => state.clearSnackBar);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(clearSnackBar, 3200);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [message, clearSnackBar]);
+
+  return createPortal(
+    <div key={Math.random()} css={styles.snackbar(!!message)}>
+      {message && <div>{message.message}</div>}
+    </div>,
+    document.body
+  );
+}

--- a/src/components/SnackBar/styles.ts
+++ b/src/components/SnackBar/styles.ts
@@ -1,0 +1,33 @@
+import { css, keyframes } from '@emotion/react';
+import { colors } from '@styles/theme';
+
+const fadeIn = keyframes({
+  from: { bottom: 0, opacity: 0 },
+  to: { bottom: 40, opacity: 1 },
+});
+
+const fadeOut = keyframes({
+  from: { bottom: 40, opacity: 1 },
+  to: { bottom: 0, opacity: 0 },
+});
+
+export const styles = {
+  snackbar: (visible: boolean) =>
+    css({
+      visibility: visible ? 'visible' : 'hidden',
+      zIndex: 100,
+      position: 'fixed',
+      bottom: 40,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      animation: visible ? `${fadeIn} .5s, ${fadeOut} .5s 3s` : undefined,
+      width: '90%',
+      maxWidth: 300,
+      margin: '0 auto',
+      padding: '1rem',
+      borderRadius: 4,
+      background: 'rgba(0,0,0,0.6)',
+      color: colors.white,
+      textAlign: 'center',
+    }),
+};

--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -3,7 +3,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { KBO_LEAGUE_STADIUMS, KBOTeams } from '@constants/global';
 import { TeamId } from '@typings/db';
 
-interface TicketFormContext {
+export interface TicketFormContext {
   matchDate: {
     year: number;
     month: number;

--- a/src/pages/Layout/index.tsx
+++ b/src/pages/Layout/index.tsx
@@ -1,10 +1,12 @@
 import { Outlet } from 'react-router-dom';
 import Header from '@components/Header';
+import SnackBar from '@components/SnackBar';
 import { styles } from './styles';
 
 export default function Layout() {
   return (
     <>
+      <SnackBar />
       <Header />
       <main css={styles.inner}>
         <Outlet />

--- a/src/pages/Register/TicketForm/index.tsx
+++ b/src/pages/Register/TicketForm/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Button from '@components/common/Button';
 import ConfirmTicket from '@components/ConfirmTicket';
 import ProgressIndicator from '@components/ProgressIndicator';
@@ -8,6 +9,8 @@ import SetMatchScore from '@components/SetMatchScore';
 import SetMatchSeason from '@components/SetMatchSeason';
 import SetMyTeam from '@components/SetMyTeam';
 import { useTicketForm } from '@context/TicketFormContext';
+import { createTicket } from '@services/tickets';
+import { useSnackBarStore } from '@store/useSnackBarStore';
 import { styles } from './styles';
 
 function renderTicketRegisterForm(step: number) {
@@ -33,6 +36,8 @@ export default function TicketForm() {
   const [formStep, setFormStep] = useState(1);
   const lastStep = stepTitles.length;
   const ticketForm = useTicketForm();
+  const openSnackBar = useSnackBarStore(state => state.openSnackBar);
+  const navigate = useNavigate();
 
   function prevStep() {
     setFormStep(prev => prev - 1);
@@ -71,9 +76,20 @@ export default function TicketForm() {
     return true;
   }
 
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const ticket = {
+      ...ticketForm,
+      matchDate: `${ticketForm.matchDate.year}.${ticketForm.matchDate.month}.${ticketForm.matchDate.date}`,
+    };
+    await createTicket(ticket);
+    openSnackBar('새로운 티켓이 등록되었습니다.');
+    navigate('/');
+  }
+
   return (
     <section>
-      <form css={styles.form}>
+      <form css={styles.form} onSubmit={onSubmit}>
         <h2>티켓 등록</h2>
         <ProgressIndicator step={formStep} stepTitles={stepTitles} />
         {renderTicketRegisterForm(formStep)}

--- a/src/services/tickets.ts
+++ b/src/services/tickets.ts
@@ -1,0 +1,8 @@
+import { TicketFormContext } from '@context/TicketFormContext';
+import { httpClient } from '.';
+
+type TicketForm = Omit<TicketFormContext, 'matchDate'> & { matchDate: string };
+
+export function createTicket(ticket: TicketForm) {
+  return httpClient.post('/tickets', ticket);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,4 @@
 export * from './useUserStore';
 export * from './useModalStore';
 export * from './useTeamStore';
+export * from './useSnackBarStore';

--- a/src/store/useSnackBarStore.ts
+++ b/src/store/useSnackBarStore.ts
@@ -1,0 +1,17 @@
+import create from 'zustand';
+
+interface SnackBarState {
+  message: { message: string } | null;
+  openSnackBar(message: string): void;
+  clearSnackBar(): void;
+}
+
+export const useSnackBarStore = create<SnackBarState>()(set => ({
+  message: null,
+  openSnackBar(message) {
+    set({ message: { message } });
+  },
+  clearSnackBar() {
+    set({ message: null });
+  },
+}));


### PR DESCRIPTION
## What is this PR?

close #69 

## Changes

스낵바에 `key` 값을 전달한 것은, 스낵바의 메세지 상태가 변화하여 언마운트가 발생해도
항상 같은 요소가 재사용되기 때문에 항상 새로운 메세지 값과 애니메이션이 적용이 되는 것을 보장할 수 없음.
`key` 값을 랜덤하게 주어, 변경 전의 요소와 후의 요소가 다르다는 것을 리액트에게 인지하도록 하기 위함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 티켓 등록 과정 |  ![Animation](https://user-images.githubusercontent.com/37580351/195787775-ebe709b7-080c-4ffb-88b2-639aa253ba8f.gif) |

## Test Checklist

스크린샷 참고

## Etc

큰 화면에서 스낵바의 위치가 다소 눈에 들어오지 않음.
