### PR TITLE
Feat: my teams 변경 성공시, 스낵바 메세지 띄우기 기능 구현

### DIFF
--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -31,7 +31,7 @@ export default function TeamPicker() {
     const isChanged =
       myTeams.length !== pickedTeams.length ||
       (pickedTeams.length > 0 &&
-        pickedTeams.some(pickedTeam => myTeams.includes(pickedTeam)));
+        pickedTeams.some(pickedTeam => !myTeams.includes(pickedTeam)));
 
     if (isChanged) {
       await setMyTeams(pickedTeams);

--- a/src/components/TeamPicker/index.tsx
+++ b/src/components/TeamPicker/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Button from '@components/common/Button';
 import PickTeamList from '@components/PickTeamList';
 import TeamPickerList from '@components/TeamPickerList';
-import { useModalStore, useTeamStore } from '@store/.';
+import { useModalStore, useSnackBarStore, useTeamStore } from '@store/.';
 import { TeamId, TeamName } from '@typings/db';
 import { styles } from './styles';
 
@@ -11,6 +11,7 @@ export default function TeamPicker() {
   const myTeams = useTeamStore(state => state.myTeams);
   const setMyTeams = useTeamStore(state => state.setMyTeams);
   const [pickedTeams, setPickedTeams] = useState(myTeams);
+  const openSnackBar = useSnackBarStore(state => state.openSnackBar);
 
   function onChangeTeam(
     e: React.ChangeEvent<
@@ -26,17 +27,18 @@ export default function TeamPicker() {
     }
   }
 
-  function savePickedTeams() {
+  async function savePickedTeams() {
     const isChanged =
       myTeams.length !== pickedTeams.length ||
       (pickedTeams.length > 0 &&
         pickedTeams.some(pickedTeam => myTeams.includes(pickedTeam)));
 
     if (isChanged) {
-      setMyTeams(pickedTeams);
-    } else {
-      closeModal();
+      await setMyTeams(pickedTeams);
+      openSnackBar('MY팀이 변경되었습니다.');
     }
+
+    closeModal();
   }
 
   return (

--- a/src/store/useTeamStore.ts
+++ b/src/store/useTeamStore.ts
@@ -1,7 +1,6 @@
 import create from 'zustand';
 import * as TeamService from '@services/teams';
 import { TeamId } from '@typings/db';
-import { useModalStore } from './useModalStore';
 
 interface TeamState {
   myTeams: TeamId[];
@@ -15,7 +14,6 @@ export const useTeamStore = create<TeamState>()(set => ({
     try {
       await TeamService.updateMyTeams(teams);
       set({ myTeams: teams });
-      useModalStore.setState({ modal: '' });
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
## What is this PR?

close #23 

## Changes

- 모달 닫기 코드는 변경 여부에 관계없이 중복 코드여서 분기처리함.
- 하나의 스토어에서 관련 모델 api의 비동기 처리 로직 외에는 다른 스토어 상태 로직은 처리하지 않도록 함.

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| 변경된 팀이 없을 때 | <img src="https://user-images.githubusercontent.com/37580351/195800724-37e68567-bc4e-408f-8f96-459031814e6b.gif" width="50%"> |
| 변경된 팀이 있을 때 | <img src="https://user-images.githubusercontent.com/37580351/195800746-f9a2ee0b-72b7-4fbb-8fe6-22280071c962.gif" width="50%"> |

## Test Checklist

- [x] #89 에서 생성한 스낵바 컴포넌트의 고유한 key 값을 통해,
스낵바 메세지가 띄워져 있는 상황에서 새로운 스낵바 메세지를 띄워도 이전의 메세지를 새로운 메세지가 대체하는 것 확인.

## Etc

없음
