### PR TITLE
Fix: change getScoreType fn first argument value

### DIFF
--- a/src/context/TicketFormContext.tsx
+++ b/src/context/TicketFormContext.tsx
@@ -109,7 +109,7 @@ const ticketFormReducer: React.Reducer<TicketFormContext, TicketFormActions> = (
         scoreType:
           state.homeTeam == state.myTeam
             ? getScoreType(action.score, state.score.awayTeam)
-            : getScoreType(state.score.homeTeam, action.score),
+            : getScoreType(state.score.awayTeam, action.score),
       };
   }
 };


### PR DESCRIPTION
## What is this PR?

close #61 

## Changes

스코어 타입을 리턴하는 함수의 인자값을 원정팀이 아닌 홈팀으로 잘못 전달해서 발생한 문제.

## Screenshot

<img src="https://user-images.githubusercontent.com/37580351/197229006-0fd8de35-66cf-4bf5-8c43-563ebe8a42dc.png" width="30%" >

## Test Checklist

스크린샷 참고

## Etc

없음
