### PR TITLE
Feat: sticky navigation bar

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,11 +1,32 @@
+import { useEffect, useState } from 'react';
 import CustomLink from '~/components/CustomLink';
+import useElementRect from '~/hooks/useElementRect';
 import { styles } from './styles';
 
 export default function NavBar() {
+  const [sticky, setSticky] = useState(false);
+  const [navRectRef, setNavRef] = useElementRect();
+
+  useEffect(() => {
+    function handleScroll() {
+      if (navRectRef.current) {
+        navRectRef.current.y < window.scrollY
+          ? setSticky(true)
+          : setSticky(false);
+      }
+    }
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
   return (
-    <nav css={styles.navList}>
-      <CustomLink to="/">직관 히스토리</CustomLink>
-      <CustomLink to="myteam">MY 팀</CustomLink>
+    <nav css={[styles.navList, sticky && styles.sticky]} ref={setNavRef}>
+      <div>
+        <CustomLink to="/">직관 히스토리</CustomLink>
+        <CustomLink to="myteam">MY 팀</CustomLink>
+      </div>
     </nav>
   );
 }

--- a/src/components/NavBar/styles.ts
+++ b/src/components/NavBar/styles.ts
@@ -4,9 +4,12 @@ import { colors } from '~/styles/theme';
 
 export const styles = {
   navList: css({
+    background: colors.white,
     width: '100%',
-    display: 'flex',
-    borderBottom: `1px solid ${colors.gray[100]}`,
+    div: {
+      display: 'flex',
+      borderBottom: `1px solid ${colors.gray[100]}`,
+    },
     a: {
       width: '50%',
       height: 50,
@@ -29,8 +32,16 @@ export const styles = {
       },
     },
     [mq('lg')]: {
-      width: 1200,
-      margin: '0 auto',
+      div: {
+        width: 1200,
+        margin: '0 auto',
+      },
     },
+  }),
+  sticky: css({
+    zIndex: 100,
+    position: 'fixed',
+    top: 0,
+    left: 0,
   }),
 };

--- a/src/hooks/useElementRect.ts
+++ b/src/hooks/useElementRect.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+import useElement from './useElement';
+
+export default function useElementRect() {
+  const [elementRef, setElementRef] = useElement();
+  const rectRef = useRef<DOMRect>();
+
+  useEffect(() => {
+    if (elementRef.current) {
+      rectRef.current = elementRef.current.getBoundingClientRect();
+    }
+  });
+
+  return [rectRef, setElementRef] as const;
+}


### PR DESCRIPTION
## What is this PR?

close #99 

## Changes

페이지의 컨텐츠로 인해 스크롤이 발생했을 때, 네비게이션 요소 특정 위치에서 고정 기능 구현

## Screenshot

|  기능  | 스크린샷 |
| :----: | :------: |
| mobile | <img src="https://user-images.githubusercontent.com/37580351/197390362-24948b03-1bac-43e9-ba5e-19b3c82e5322.gif" width="30%"> |
| desktop | <img src="https://user-images.githubusercontent.com/37580351/197390358-d6608921-52f9-4f97-97ea-0bd51564de9b.gif"> |

## Test Checklist

스크린샷 참고

## Etc

요소의 `offsetTop` 프로퍼티를 사용하는 방법으로도 해당 기능 구현이 가능함.
그러나, 이 프로퍼티는 컨테이닝 블록과의 거리를 기준으로 요소의 좌표 값을 얻기 때문에
마크업과 스타일 코드에 영향을 받을 수 있어 사용하지 않음.
